### PR TITLE
[DPE-9013] fix docs link for charmhub release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,11 +11,11 @@ description: |
   Valkey is a flexible distributed key-value database that is optimized 
   for caching and other realtime workloads. This charmed operator deploys 
   and operates Valkey in Kubernetes and VM environments.
-docs: charmhub.io # to be updated
+docs: https://charmhub.io/valkey # to be updated
 source: https://github.com/canonical/charmed-valkey-operator
 issues: https://github.com/canonical/charmed-valkey-operator/issues
 website:
-  - https://charmhub.io/valkey-k8s
+  - https://charmhub.io/valkey
   - https://github.com/canonical/charmed-valkey-operator
   - https://matrix.to/#/%23charmhub-data-platform%3Aubuntu.com
 


### PR DESCRIPTION
Release to charmhub failed due to invalid docs link in `metadata.yaml`, see [CI job](https://github.com/canonical/charmed-valkey-operator/actions/runs/20998200404/job/60361719632#step:12:50).

This PR adds a valid link, which is to be updated once the read-the-docs project is set up.