### PR TITLE
fix CI and update docs link

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -71,7 +71,7 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a") as file:
               file.write(output)
       - name: Generate Allure default test results
-        if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
+        # if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
         run: tox run -e integration -- tests/integration --allure-default-dir=allure-default-results
       - name: Upload Allure default results
         # Default test results in case the integration tests time out or runner set up fails

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -76,7 +76,7 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "a") as file:
               file.write(output)
       - name: Generate Allure default test results
-        # if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
+        if: ${{ github.event_name == 'schedule' && github.run_attempt == '1' }}
         run: tox run -e integration -- tests/integration --allure-default-dir=allure-default-results
       - name: Upload Allure default results
         # Default test results in case the integration tests time out or runner set up fails

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -27,6 +27,11 @@ jobs:
           sudo snap install go --classic
           go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
+          # to build Valkey-glide during tests
+          sudo apt install libprotobuf-dev protobuf-compiler -y
+          sudo apt install rustup -y
+          rustup set profile minimal
+          rustup default 1.90.0
       - name: Collect spread jobs
         id: collect-jobs
         shell: python

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -17,7 +17,7 @@ jobs:
   collect-integration-tests:
     name: Collect spread jobs | ${{ inputs.path-to-charm-directory }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ description: |
   Valkey is a flexible distributed key-value database that is optimized 
   for caching and other realtime workloads. This charmed operator deploys 
   and operates Valkey in Kubernetes and VM environments.
-docs: https://charmhub.io/valkey # to be updated
+docs: https://canonical-charmed-valkey.readthedocs-hosted.com/en/latest/
 source: https://github.com/canonical/charmed-valkey-operator
 issues: https://github.com/canonical/charmed-valkey-operator/issues
 website:


### PR DESCRIPTION
This PR fixes the CI (nightly test run [fails](https://github.com/canonical/valkey-operator/actions/runs/21500907628/job/61947096168) since #4 was merged). A successful test run for that step can be seen [here](https://github.com/canonical/valkey-operator/actions/runs/21510063783/job/61975081119), otherwise it only runs on scheduled jobs.

Furthermore the PR updates the docs link in `metadata.yaml` to the Read-the-docs project.
