### PR TITLE
chore: improve stability of integration tests

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -131,7 +131,7 @@ jobs:
           sudo apt install libprotobuf-dev protobuf-compiler -y
           # 22.04 installs rustup from snap
           # sudo apt install rustup -y
-          snap install rustup --classic
+          sudo snap install rustup --classic
           rustup set profile minimal
           rustup default 1.90.0
       - name: Download packed charm(s)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,6 +119,11 @@ jobs:
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v5
+      # todo: remove when switching back to 24.04 runners
+      - name: Install Python for tests
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
       - name: Set up environment
         timeout-minutes: 5
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -129,7 +129,9 @@ jobs:
           go install github.com/snapcore/spread/cmd/spread@latest
           # to build Valkey-glide during tests
           sudo apt install libprotobuf-dev protobuf-compiler -y
-          sudo apt install rustup -y
+          # 22.04 installs rustup from snap
+          # sudo apt install rustup -y
+          snap install rustup --classic
           rustup set profile minimal
           rustup default 1.90.0
       - name: Download packed charm(s)

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -123,6 +123,7 @@ jobs:
         timeout-minutes: 5
         run: |
           sudo apt update
+          snap info lxd
           sudo snap install charmcraft --classic
           sudo snap install go --classic
           go install github.com/snapcore/spread/cmd/spread@latest

--- a/spread.yaml
+++ b/spread.yaml
@@ -96,7 +96,7 @@ backends:
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
     systems:
-      - ubuntu-24.04:
+      - ubuntu-22.04:
           username: runner
 
 suites:

--- a/spread.yaml
+++ b/spread.yaml
@@ -85,6 +85,9 @@ backends:
       sudo systemctl start ssh
 
       sudo passwd --delete runner
+      
+      # todo: remove when switching back to 24.04 runners
+      sudo systemctl reload ssh || sudo systemctl restart ssh
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
@@ -95,6 +98,9 @@ backends:
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
+      # todo: remove when switching back to 24.04 runners
+      LD_LIBRARY_PATH: '$(HOST: echo $LD_LIBRARY_PATH)'
+      PKG_CONFIG_PATH: '$(HOST: echo $PKG_CONFIG_PATH)'
     systems:
       - ubuntu-22.04:
           username: runner
@@ -111,6 +117,7 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
+  pythonLocation: '$(HOST: echo $pythonLocation)'
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
@@ -153,6 +160,7 @@ prepare: |
   fi
 
   pipx install tox poetry
+  poetry env use $pythonLocation/bin/python
   rustup default 1.90.0
 prepare-each: |
   cd "$SPREAD_PATH"
@@ -170,3 +178,4 @@ prepare-each: |
   # Unable to set constraint on all models because of Juju bug:
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
+  poetry env use $pythonLocation/bin/python

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -220,9 +220,9 @@ async def test_user_secret_permissions(juju: jubilant.Juju) -> None:
     )
 
     logger.info("Secret access will be granted now - wait for updated password")
+    juju.grant_secret(identifier=secret_name, app=APP_NAME)
     # deferred `config_changed` event will be retried before `update_status`
     with fast_forward(juju):
-        juju.grant_secret(identifier=secret_name, app=APP_NAME)
         juju.wait(
             lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=10),
             timeout=1200,

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -274,6 +274,10 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
 
     logger.info("Waiting for CA certificate to expire")
     sleep(CA_EXPIRY_TIME)
+    juju.wait(
+        lambda status: are_agents_idle(status, APP_NAME, idle_period=10, unit_count=NUM_UNITS),
+        timeout=600,
+    )
 
     logger.info("Check access with previous certificate fails after expiration")
     with pytest.raises(Exception) as exc_info:

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -218,7 +218,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_NAME}:certificates")
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=100,
+        timeout=600,
     )
 
     logger.info("Adjust CA and certificate validity on TLS provider")


### PR DESCRIPTION
small fixes:
- `test_charm.py`: grant the secret in time before forcing the deferred event again
- `test_certificate_rotation.py`: wait for agents to be active/idle after CA has expired before checking access