### PR TITLE
[DPE-9679] - Fix spread installation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -26,7 +26,7 @@ jobs:
           sudo apt update
           sudo snap install charmcraft --classic
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
           # to build Valkey-glide during tests
           sudo apt install libprotobuf-dev protobuf-compiler -y
@@ -125,7 +125,7 @@ jobs:
           sudo apt update
           sudo snap install charmcraft --classic
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           # to build Valkey-glide during tests
           sudo apt install libprotobuf-dev protobuf-compiler -y
           sudo apt install rustup -y


### PR DESCRIPTION
This pull request updates the integration test workflow to use the `spread` tool from the `canonical` GitHub organization instead of `snapcore`. This ensures that the workflow uses the correct and maintained version of the `spread` tool.

CI workflow updates:

* Updated the `go install` command in `.github/workflows/integration_test.yaml` to fetch `spread` from `github.com/canonical/spread/cmd/spread` instead of `github.com/snapcore/spread/cmd/spread`. [[1]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L29-R29) [[2]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L128-R128)