### PR TITLE
fix: unblock CI by switching to self-hosted runners

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -102,20 +102,9 @@ jobs:
     runs-on: ${{ matrix.job.runner }}
     timeout-minutes: 226 # Sum of steps `timeout-minutes` + 5
     steps:
-      - name: Free up disk space
-        timeout-minutes: 10
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /opt/hostedtoolcache/
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/julia*
-          sudo apt purge -y firefox google-chrome-stable microsoft-edge-stable
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
+      - name: Disk usage
+        timeout-minutes: 5
+        run: df --human-readable
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v5

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -127,7 +127,7 @@ jobs:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
       - name: Run spread job
-        timeout-minutes: 180
+        timeout-minutes: 60
         id: spread
         run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
       - name: Upload Allure results

--- a/spread.yaml
+++ b/spread.yaml
@@ -96,8 +96,8 @@ backends:
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
     systems:
-      - ubuntu-24.04:
-          username: runner
+      - self-hosted-linux-amd64-noble-medium:
+          username: ubuntu
 
 suites:
   tests/spread/k8s/:

--- a/spread.yaml
+++ b/spread.yaml
@@ -84,7 +84,7 @@ backends:
       sudo systemctl daemon-reload
       sudo systemctl start ssh
 
-      sudo passwd --delete runner
+      sudo passwd --delete ubuntu
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -220,9 +220,9 @@ async def test_user_secret_permissions(juju: jubilant.Juju) -> None:
     )
 
     logger.info("Secret access will be granted now - wait for updated password")
+    juju.grant_secret(identifier=secret_name, app=APP_NAME)
     # deferred `config_changed` event will be retried before `update_status`
     with fast_forward(juju):
-        juju.grant_secret(identifier=secret_name, app=APP_NAME)
         juju.wait(
             lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=10),
             timeout=1200,

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -274,6 +274,10 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
 
     logger.info("Waiting for CA certificate to expire")
     sleep(CA_EXPIRY_TIME)
+    juju.wait(
+        lambda status: are_agents_idle(status, APP_NAME, idle_period=10, unit_count=NUM_UNITS),
+        timeout=600,
+    )
 
     logger.info("Check access with previous certificate fails after expiration")
     with pytest.raises(Exception) as exc_info:

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -218,7 +218,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_NAME}:certificates")
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=100,
+        timeout=600,
     )
 
     logger.info("Adjust CA and certificate validity on TLS provider")

--- a/tests/spread/k8s/test_certificate_rotation.py/task.yaml
+++ b/tests/spread/k8s/test_certificate_rotation.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_certificate_rotation.py
 environment:
   TEST_MODULE: test_certificate_rotation.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/k8s/test_charm.py/task.yaml
+++ b/tests/spread/k8s/test_charm.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_charm.py
 environment:
   TEST_MODULE: test_charm.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/k8s/test_private_key.py/task.yaml
+++ b/tests/spread/k8s/test_private_key.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_private_key.py
 environment:
   TEST_MODULE: test_private_key.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/k8s/test_scaling.py/task.yaml
+++ b/tests/spread/k8s/test_scaling.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_scaling.py
 environment:
   TEST_MODULE: ha/test_scaling.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/k8s/test_tls.py/task.yaml
+++ b/tests/spread/k8s/test_tls.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_tls.py
 environment:
   TEST_MODULE: test_tls.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_certificate_rotation.py/task.yaml
+++ b/tests/spread/vm/test_certificate_rotation.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_certificate_rotation.py
 environment:
   TEST_MODULE: test_certificate_rotation.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_charm.py/task.yaml
+++ b/tests/spread/vm/test_charm.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_charm.py
 environment:
   TEST_MODULE: test_charm.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_private_key.py/task.yaml
+++ b/tests/spread/vm/test_private_key.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_private_key.py
 environment:
   TEST_MODULE: test_private_key.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_scaling.py/task.yaml
+++ b/tests/spread/vm/test_scaling.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_scaling.py
 environment:
   TEST_MODULE: ha/test_scaling.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_tls.py/task.yaml
+++ b/tests/spread/vm/test_tls.py/task.yaml
@@ -1,6 +1,8 @@
 summary: test_tls.py
 environment:
   TEST_MODULE: test_tls.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/tls/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:


### PR DESCRIPTION
Due to https://bugs.launchpad.net/ubuntu/+source/apparmor/+bug/2146972, integration tests randomly fail in CI to a state that we are blocked on any PR. While a possible workaround would be to switch to `22.04` runners on Github, this would require a lot of workarounds to be able to use `valkey-glide`, therefor this PR switches the integration tests in CI to self-hosted runners instead.

The PR also includes some minor improvements/fixes for two unstable integration tests:
- `test_charm.py`: grant the secret in time before forcing the deferred event again
-  `test_certificate_rotation.py`: wait for agents to be active/idle after CA has expired before checking access