### PR TITLE
Bugfix: avoid errors for building IP and DNS SANs

### DIFF
--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -97,7 +97,7 @@ class TLSManager(ManagerStatusProtocol):
         """Build the SANs IP for the TLS certificate."""
         sans_ip = set()
 
-        if not self.state.peer_relation:
+        if not self.state.unit_server.model:
             return frozenset(sans_ip)
 
         if self.extra_sans_config_is_valid() and (
@@ -120,9 +120,8 @@ class TLSManager(ManagerStatusProtocol):
             frozenset[str]: The SANs DNS.
         """
         sans_dns = set()
-        sans_dns.add(self.state.unit_server.unit_name.replace("/", ""))
 
-        if not self.state.peer_relation:
+        if not self.state.unit_server.model:
             return frozenset(sans_dns)
 
         if self.extra_sans_config_is_valid() and (
@@ -135,7 +134,8 @@ class TLSManager(ManagerStatusProtocol):
                 if not self._is_ip_address(san)
             }
 
-        sans_dns.add(self.state.unit_server.model.hostname)
+        sans_dns.add(self.state.unit_server.unit_name.replace("/", ""))
+        sans_dns.add(self.state.hostname)
 
         return frozenset(sans_dns)
 

--- a/tests/integration/tls/test_certificate_options.py
+++ b/tests/integration/tls/test_certificate_options.py
@@ -108,6 +108,7 @@ def test_extra_sans_config_option(juju: jubilant.Juju) -> None:
     assert expected_sans in client_cert_sans, (
         f"expected sans {expected_sans} not found in certificate sans {client_cert_sans}"
     )
+    assert unit_name.replace("/", "") in client_cert_sans, "unit name not found in DNS SANs"
 
     logger.info("Resetting configuration for extra-sans")
     juju.config(app=APP_NAME, reset="certificate-extra-sans")

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1110,7 +1110,7 @@ def test_set_extra_sans_config_option(cloud_spec):
 
     current_sans_value = (
         "X509v3 Subject Alternative Name: \n    "
-        "DNS:valkey-0.valkey-endpoints, "
+        "DNS:valkey0, DNS:valkey-0.valkey-endpoints, "
         "IP Address:127.1.1.1, IP Address:192.0.2.0"
     )
     with (
@@ -1144,7 +1144,7 @@ def test_set_extra_sans_config_option_unit_placeholder(cloud_spec):
 
     current_sans_value = (
         "X509v3 Subject Alternative Name: \n    "
-        "DNS:myhostname, DNS:valkey-0.valkey-endpoints, "
+        "DNS:myhostname, DNS:valkey0, DNS:valkey-0.valkey-endpoints, "
         "IP Address:127.1.1.1, IP Address:192.168.1.100, IP Address:192.0.2.0"
     )
     with (
@@ -1254,7 +1254,7 @@ def test_set_extra_sans_config_option_no_update(cloud_spec):
 
     current_sans_value = (
         "X509v3 Subject Alternative Name: \n    "
-        "DNS:myhostname, DNS:valkey-0.valkey-endpoints, "
+        "DNS:myhostname, DNS:valkey0, DNS:valkey-0.valkey-endpoints, "
         "IP Address:127.1.1.1, IP Address:192.168.1.100, IP Address:192.0.2.0"
     )
     with (


### PR DESCRIPTION
In some cases, it can happen that the charm code tries to build SANs IP and DNS names before the peer relation model is ready. This results in uncaught errors (self-resolving), example: https://github.com/canonical/valkey-operator/actions/runs/23968250108/job/69912976655#step:11:162

The PR adjusts the logic for building SAN names by returning early in these cases. Thereby it also fixes a bug where the unit name was removed from the SAN DNS entries.