### PR TITLE
fix: unblock CI integration tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -95,7 +95,7 @@ backends:
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
-      CONCIERGE_MICROK8S_CHANNEL: 1.34/stable
+      CONCIERGE_MICROK8S_CHANNEL: 1.34-strict/stable
     systems:
       - self-hosted-linux-amd64-noble-medium:
           username: ubuntu

--- a/spread.yaml
+++ b/spread.yaml
@@ -95,6 +95,7 @@ backends:
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
+      CONCIERGE_MICROK8S_CHANNEL: 1.34/stable
     systems:
       - self-hosted-linux-amd64-noble-medium:
           username: ubuntu
@@ -122,7 +123,7 @@ prepare: |
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
 
-    snap install microk8s --channel "latest/stable" --classic
+    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
 
     # Wait for microk8s to populate iptables
     # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -343,10 +343,10 @@ def set_password(
 
 
 @contextmanager
-def fast_forward(juju: jubilant.Juju):
+def fast_forward(juju: jubilant.Juju, update_interval: str = "10s"):
     """Context manager that temporarily speeds up update-status hooks to fire every 10s."""
     old = juju.model_config()["update-status-hook-interval"]
-    juju.model_config({"update-status-hook-interval": "10s"})
+    juju.model_config({"update-status-hook-interval": update_interval})
     try:
         yield
     finally:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -222,9 +222,9 @@ async def test_user_secret_permissions(juju: jubilant.Juju) -> None:
     logger.info("Secret access will be granted now - wait for updated password")
     juju.grant_secret(identifier=secret_name, app=APP_NAME)
     # deferred `config_changed` event will be retried before `update_status`
-    with fast_forward(juju):
+    with fast_forward(juju, update_interval="30s"):
         juju.wait(
-            lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=30),
+            lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=10),
             timeout=1200,
         )
 


### PR DESCRIPTION
The PR fixes most of the issues we have recently seen on CI.

Changes:
- downgrade `MicroK8s` to `1.34-strict` as `1.35` has issues and does not seem to be updated frequently; this addresses the various failures of `snap install microk8s` (I was able to reproduce a few of them locally, they do not appear with `1.34`)
- fix timing issue in `test_charm.py` with fast_forward usage when waiting for a secret change to be applied
