### PR TITLE
fix: CA rotation integration test

### DIFF
--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -264,6 +264,7 @@ class TLSEvents(ops.Object):
                 )
                 self.charm.sentinel_manager.restart_service()
             except (
+                ValkeyCannotGetPrimaryIPError,
                 ValkeyWorkloadCommandError,
                 ValkeyServicesFailedToStartError,
                 ValkeyTLSLoadError,
@@ -287,6 +288,7 @@ class TLSEvents(ops.Object):
             )
             self.charm.sentinel_manager.restart_service()
         except (
+            ValkeyCannotGetPrimaryIPError,
             ValkeyWorkloadCommandError,
             ValkeyServicesFailedToStartError,
             ValkeyTLSLoadError,

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -92,8 +92,8 @@ class ValkeyVmWorkload(WorkloadBase):
             revision = str(SNAP_REVISION)
 
         try:
-            # as long as 26.04 is not stable, we need to install the core26 snap from edge
-            snap.add("core26", channel="edge")
+            # as long as 26.04 is not stable, we need to install the core26 snap from beta
+            snap.add("core26", channel="beta")
 
             self.valkey.ensure(snap.SnapState.Present, revision=revision)
             self.valkey.hold()

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -32,7 +32,7 @@ NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
 CERTIFICATE_EXPIRY_TIME = 320
-CA_EXPIRY_TIME = 500
+CA_EXPIRY_TIME = 380
 
 
 def _prepare_units_for_ca_expiration_test(juju: jubilant.Juju) -> None:
@@ -215,7 +215,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
     logger.info("Adjust CA and certificate validity on TLS provider")
-    tls_config = {"certificate-validity": "4m", "root-ca-validity": "10m"}
+    tls_config = {"certificate-validity": "5m", "root-ca-validity": "10m"}
     juju.config(app=TLS_NAME, values=tls_config)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -62,7 +62,7 @@ def test_build_and_deploy(charm: str, juju: jubilant.Juju, substrate: Substrate)
     juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=900,
     )
 
 

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -59,16 +59,20 @@ def test_build_and_deploy(charm: str, juju: jubilant.Juju, substrate: Substrate)
 
     tls_config = {"certificate-validity": "5m", "ca-common-name": "valkey"}
     juju.deploy(TLS_NAME, channel=TLS_CHANNEL, config=tls_config)
-    juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=900,
+        timeout=600,
     )
 
 
 async def test_certificate_expiration(juju: jubilant.Juju) -> None:
     """Test the TLS certificate expiration and renewal on a running cluster."""
-    _prepare_units_for_ca_expiration_test(juju)
+    logger.info("Enabling TLS")
+    juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
+    juju.wait(
+        lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
+        timeout=600,
+    )
 
     logger.info("Downloading TLS certificate from deployed app.")
     download_client_certificate_from_unit(juju, APP_NAME)
@@ -98,6 +102,7 @@ async def test_certificate_expiration(juju: jubilant.Juju) -> None:
         old_client_certificate = file.read()
     assert old_client_certificate, "Failed to get current client certificate"
 
+    _prepare_units_for_ca_expiration_test(juju)
     logger.info("Waiting for certificate to expire")
     sleep(CERTIFICATE_EXPIRY_TIME)
 

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -214,23 +214,9 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     The CA certificate should be rotated and the cluster should still be accessible.
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
-    logger.info("Disabling client TLS")
-    juju.remove_relation(f"{APP_NAME}:client-certificates", f"{TLS_NAME}:certificates")
-    juju.wait(
-        lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
-    )
-
     logger.info("Adjust CA and certificate validity on TLS provider")
     tls_config = {"certificate-validity": "4m", "root-ca-validity": "10m"}
     juju.config(app=TLS_NAME, values=tls_config)
-    juju.wait(
-        lambda status: are_agents_idle(status, TLS_NAME, idle_period=30),
-        timeout=600,
-    )
-
-    logger.info("Enabling client TLS again")
-    juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
         timeout=600,

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
-CERTIFICATE_EXPIRY_TIME = 320
+CERTIFICATE_EXPIRY_TIME = 220
 CA_EXPIRY_TIME = 430
 
 
@@ -57,7 +57,7 @@ def test_build_and_deploy(charm: str, juju: jubilant.Juju, substrate: Substrate)
         trust=True,
     )
 
-    tls_config = {"certificate-validity": "5m", "ca-common-name": "valkey"}
+    tls_config = {"certificate-validity": "6m", "ca-common-name": "valkey"}
     juju.deploy(TLS_NAME, channel=TLS_CHANNEL, config=tls_config)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -220,7 +220,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
     logger.info("Adjust CA and certificate validity on TLS provider")
-    tls_config = {"certificate-validity": "6m", "root-ca-validity": "10m"}
+    tls_config = {"certificate-validity": "6m", "root-ca-validity": "12m"}
     juju.config(app=TLS_NAME, values=tls_config)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -32,7 +32,7 @@ NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
 CERTIFICATE_EXPIRY_TIME = 320
-CA_EXPIRY_TIME = 380
+CA_EXPIRY_TIME = 430
 
 
 def _prepare_units_for_ca_expiration_test(juju: jubilant.Juju) -> None:
@@ -220,7 +220,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
     logger.info("Adjust CA and certificate validity on TLS provider")
-    tls_config = {"certificate-validity": "5m", "root-ca-validity": "10m"}
+    tls_config = {"certificate-validity": "6m", "root-ca-validity": "10m"}
     juju.config(app=TLS_NAME, values=tls_config)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -227,7 +227,7 @@ async def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
             expected_unit_statuses={APP_NAME: [TLSStatuses.CERTIFICATE_EXPIRING.value]},
             num_units={APP_NAME: NUM_UNITS},
         ),
-        timeout=100,
+        timeout=600,
     )
 
     download_client_certificate_from_unit(juju, APP_NAME)

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
-CERTIFICATE_EXPIRY_TIME = 360
+CERTIFICATE_EXPIRY_TIME = 220
 CA_EXPIRY_TIME = 430
 
 
@@ -67,6 +67,8 @@ def test_build_and_deploy(charm: str, juju: jubilant.Juju, substrate: Substrate)
 
 async def test_certificate_expiration(juju: jubilant.Juju) -> None:
     """Test the TLS certificate expiration and renewal on a running cluster."""
+    _prepare_units_for_ca_expiration_test(juju)
+
     logger.info("Enabling TLS")
     juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
@@ -102,7 +104,6 @@ async def test_certificate_expiration(juju: jubilant.Juju) -> None:
         old_client_certificate = file.read()
     assert old_client_certificate, "Failed to get current client certificate"
 
-    _prepare_units_for_ca_expiration_test(juju)
     logger.info("Waiting for certificate to expire")
     sleep(CERTIFICATE_EXPIRY_TIME)
 

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
-CERTIFICATE_EXPIRY_TIME = 220
+CERTIFICATE_EXPIRY_TIME = 360
 CA_EXPIRY_TIME = 430
 
 


### PR DESCRIPTION
This PR includes a few minor fixes and improvements for the CA rotation integration test, that recently always fails on K8s, presumably because it just takes longer. When K8s tests are executed locally, they always pass.

The changes are:
- catch `ValkeyCannotGetPrimaryIPError` that might be raised by `sentinel_manager.get_primary_ip()` (missed after the error handling was changed on the method), see [this CI run](https://github.com/canonical/valkey-operator/actions/runs/24444439636/job/71433499795#step:12:13271)
- no longer deploy with TLS from the start, to avoid TLS certs to become invalid while startup still in progress, see [this CI run](https://github.com/canonical/valkey-operator/actions/runs/24444439636/job/71455753256#step:11:15)
- simplify the test by removing the disabling and re-enabling of TLS in between; there is actually no need to do that, we can just change the configuration of the TLS provider
- adjust validity time of the certificates in the test to allow for reloading before the certificate actually expires

Unrelated change:
- update `core26` snap to `beta` channel on VM