### PR TITLE
patch: Update timout for failvoer to 190s

### DIFF
--- a/src/common/client.py
+++ b/src/common/client.py
@@ -372,9 +372,11 @@ class SentinelClient(CliClient):
             == "OK"
         )
 
+    # wait for 3m+10 for the failover to finish
+    # sentinel waits 3m before timing out a failover
     @retry(
-        stop=stop_after_attempt(5),
-        wait=wait_fixed(2),
+        stop=stop_after_attempt(19),
+        wait=wait_fixed(10),
         retry=retry_if_result(lambda in_progress: in_progress),
         retry_error_callback=lambda _: True,
     )


### PR DESCRIPTION
This pull request adjusts the retry logic for the coordinated primary failover process to better accommodate the expected duration of a failover operation. The main change is to increase the total wait time and interval between retries, ensuring the process aligns with the 3-minute timeout used by Sentinel.

Failover process reliability:

* Increased the number of retry attempts from 5 to 19 and the wait interval between retries from 2 seconds to 10 seconds in the `failover_primary_coordinated` method in `src/common/client.py`, allowing up to 3 minutes and 10 seconds for the failover to complete, matching Sentinel's timeout behavior.