### PR TITLE
patch: add arm support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ common/poetry.lock
 __pycache__
 coverage.xml
 .coverage
+.zed

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,9 +3,9 @@
 
 type: charm
 platforms:
-    ubuntu@24.04:amd64: # to be updated once 26.04 is released to stable
-    # TODO add tests on ARM
-    ubuntu@24.04:arm64: # to be updated once 26.04 is released to stable
+  ubuntu@24.04:amd64: # to be updated once 26.04 is released to stable
+  # TODO add tests on ARM
+  ubuntu@24.04:arm64: # to be updated once 26.04 is released to stable
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml
@@ -15,83 +15,82 @@ platforms:
 #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L290-L293
 #   https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L156-L157)
 parts:
-    # "poetry-deps" part name is a magic constant
-    # https://github.com/canonical/craft-parts/pull/901
-    poetry-deps:
-        plugin: nil
-        build-packages:
-            - curl
-        override-build: |
-            # Use environment variable instead of `--break-system-packages` to avoid failing on older
-            # versions of pip that do not recognize `--break-system-packages`
-            # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
-            PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
+  # "poetry-deps" part name is a magic constant
+  # https://github.com/canonical/craft-parts/pull/901
+  poetry-deps:
+    plugin: nil
+    build-packages:
+      - curl
+    override-build: |
+      # Use environment variable instead of `--break-system-packages` to avoid failing on older
+      # versions of pip that do not recognize `--break-system-packages`
+      # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
+      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
 
-            # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
-            curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
-            # poetry 2.0.0 requires Python >=3.9
-            if ! "$HOME/.local/bin/uv" python find '>=3.9'
-            then
-              # Use first Python version that is >=3.9 and available in an Ubuntu LTS
-              # (to reduce the number of Python versions we use)
-              "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
-            fi
-            "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
+      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
+      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
+      # poetry 2.0.0 requires Python >=3.9
+      if ! "$HOME/.local/bin/uv" python find '>=3.9'
+      then
+        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
+        # (to reduce the number of Python versions we use)
+        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
+      fi
+      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
 
-            ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
-    # "charm-poetry" part name is arbitrary; use for consistency
-    # Avoid using "charm" part name since that has special meaning to charmcraft
-    charm-poetry:
-        # By default, the `poetry` plugin creates/stages these directories:
-        # - lib, src
-        #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L76-L78)
-        # - venv
-        #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L95
-        #   https://github.com/canonical/craft-parts/blob/afb0d652eb330b6aaad4f40fbd6e5357d358de47/craft_parts/plugins/base.py#L270)
-        plugin: poetry
-        source: .
-        after:
-            - poetry-deps
-        poetry-export-extra-args:
-            ["--only", "main,charm-libs", "--without-hashes"]
-        build-packages:
-            - libffi-dev # Needed to build Python dependencies with Rust from source
-            - libssl-dev # Needed to build Python dependencies with Rust from source
-            - pkg-config # Needed to build Python dependencies with Rust from source
-            - libprotobuf-dev # Needed to build Valkey-glide
-            - protobuf-compiler # Needed to build Valkey-glide
-        override-build: |
-            # Workaround for https://github.com/canonical/charmcraft/issues/2068
-            # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
-            if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
-            then
-              snap install rustup --classic
-            else
-              apt-get install rustup -y
-            fi
+      ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
+  # "charm-poetry" part name is arbitrary; use for consistency
+  # Avoid using "charm" part name since that has special meaning to charmcraft
+  charm-poetry:
+    # By default, the `poetry` plugin creates/stages these directories:
+    # - lib, src
+    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L76-L78)
+    # - venv
+    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L95
+    #   https://github.com/canonical/craft-parts/blob/afb0d652eb330b6aaad4f40fbd6e5357d358de47/craft_parts/plugins/base.py#L270)
+    plugin: poetry
+    source: .
+    after:
+      - poetry-deps
+    poetry-export-extra-args: ["--only", "main,charm-libs", "--without-hashes"]
+    build-packages:
+      - libffi-dev # Needed to build Python dependencies with Rust from source
+      - libssl-dev # Needed to build Python dependencies with Rust from source
+      - pkg-config # Needed to build Python dependencies with Rust from source
+      - libprotobuf-dev # Needed to build Valkey-glide
+      - protobuf-compiler # Needed to build Valkey-glide
+    override-build: |
+      # Workaround for https://github.com/canonical/charmcraft/issues/2068
+      # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
+      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
+      then
+        snap install rustup --classic
+      else
+        apt-get install rustup -y
+      fi
 
-            # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
-            # archive—which means the rustup version could be updated at any time. Print rustup version
-            # to build log to make changes to the snap's rustup version easier to track
-            rustup --version
+      # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
+      # archive—which means the rustup version could be updated at any time. Print rustup version
+      # to build log to make changes to the snap's rustup version easier to track
+      rustup --version
 
-            # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
-            # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
-            rustup set profile minimal
-            rustup default 1.90.0  # renovate: charmcraft-rust-latest
+      # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
+      # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
+      rustup set profile minimal
+      rustup default 1.90.0  # renovate: charmcraft-rust-latest
 
-            craftctl default
-            # Include requirements.txt in *.charm artifact for easier debugging
-            cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
-    # "files" part name is arbitrary; use for consistency
-    files:
-        plugin: dump
-        source: .
-        after:
-            - poetry-deps # Ensure poetry is installed
-        build-packages:
-            - git
-        override-build: |
-            craftctl default
-        stage:
-            - LICENSE
+      craftctl default
+      # Include requirements.txt in *.charm artifact for easier debugging
+      cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
+  # "files" part name is arbitrary; use for consistency
+  files:
+    plugin: dump
+    source: .
+    after:
+      - poetry-deps # Ensure poetry is installed
+    build-packages:
+      - git
+    override-build: |
+      craftctl default
+    stage:
+      - LICENSE

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,7 +3,9 @@
 
 type: charm
 platforms:
-  ubuntu@24.04:amd64: # to be updated once 26.04 is released to stable
+    ubuntu@24.04:amd64: # to be updated once 26.04 is released to stable
+    # TODO add tests on ARM
+    ubuntu@24.04:arm64: # to be updated once 26.04 is released to stable
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml
@@ -13,82 +15,83 @@ platforms:
 #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L290-L293
 #   https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L156-L157)
 parts:
-  # "poetry-deps" part name is a magic constant
-  # https://github.com/canonical/craft-parts/pull/901
-  poetry-deps:
-    plugin: nil
-    build-packages:
-      - curl
-    override-build: |
-      # Use environment variable instead of `--break-system-packages` to avoid failing on older
-      # versions of pip that do not recognize `--break-system-packages`
-      # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
-      PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
+    # "poetry-deps" part name is a magic constant
+    # https://github.com/canonical/craft-parts/pull/901
+    poetry-deps:
+        plugin: nil
+        build-packages:
+            - curl
+        override-build: |
+            # Use environment variable instead of `--break-system-packages` to avoid failing on older
+            # versions of pip that do not recognize `--break-system-packages`
+            # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
+            PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
 
-      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
-      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
-      # poetry 2.0.0 requires Python >=3.9
-      if ! "$HOME/.local/bin/uv" python find '>=3.9'
-      then
-        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
-        # (to reduce the number of Python versions we use)
-        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
-      fi
-      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
+            # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
+            curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
+            # poetry 2.0.0 requires Python >=3.9
+            if ! "$HOME/.local/bin/uv" python find '>=3.9'
+            then
+              # Use first Python version that is >=3.9 and available in an Ubuntu LTS
+              # (to reduce the number of Python versions we use)
+              "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
+            fi
+            "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.2.1 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
 
-      ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
-  # "charm-poetry" part name is arbitrary; use for consistency
-  # Avoid using "charm" part name since that has special meaning to charmcraft
-  charm-poetry:
-    # By default, the `poetry` plugin creates/stages these directories:
-    # - lib, src
-    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L76-L78)
-    # - venv
-    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L95
-    #   https://github.com/canonical/craft-parts/blob/afb0d652eb330b6aaad4f40fbd6e5357d358de47/craft_parts/plugins/base.py#L270)
-    plugin: poetry
-    source: .
-    after:
-      - poetry-deps
-    poetry-export-extra-args: ['--only', 'main,charm-libs', '--without-hashes']
-    build-packages:
-      - libffi-dev  # Needed to build Python dependencies with Rust from source
-      - libssl-dev  # Needed to build Python dependencies with Rust from source
-      - pkg-config  # Needed to build Python dependencies with Rust from source
-      - libprotobuf-dev # Needed to build Valkey-glide
-      - protobuf-compiler # Needed to build Valkey-glide
-    override-build: |
-      # Workaround for https://github.com/canonical/charmcraft/issues/2068
-      # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
-      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
-      then
-        snap install rustup --classic
-      else
-        apt-get install rustup -y
-      fi
+            ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
+    # "charm-poetry" part name is arbitrary; use for consistency
+    # Avoid using "charm" part name since that has special meaning to charmcraft
+    charm-poetry:
+        # By default, the `poetry` plugin creates/stages these directories:
+        # - lib, src
+        #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L76-L78)
+        # - venv
+        #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L95
+        #   https://github.com/canonical/craft-parts/blob/afb0d652eb330b6aaad4f40fbd6e5357d358de47/craft_parts/plugins/base.py#L270)
+        plugin: poetry
+        source: .
+        after:
+            - poetry-deps
+        poetry-export-extra-args:
+            ["--only", "main,charm-libs", "--without-hashes"]
+        build-packages:
+            - libffi-dev # Needed to build Python dependencies with Rust from source
+            - libssl-dev # Needed to build Python dependencies with Rust from source
+            - pkg-config # Needed to build Python dependencies with Rust from source
+            - libprotobuf-dev # Needed to build Valkey-glide
+            - protobuf-compiler # Needed to build Valkey-glide
+        override-build: |
+            # Workaround for https://github.com/canonical/charmcraft/issues/2068
+            # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
+            if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
+            then
+              snap install rustup --classic
+            else
+              apt-get install rustup -y
+            fi
 
-      # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
-      # archive—which means the rustup version could be updated at any time. Print rustup version
-      # to build log to make changes to the snap's rustup version easier to track
-      rustup --version
+            # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
+            # archive—which means the rustup version could be updated at any time. Print rustup version
+            # to build log to make changes to the snap's rustup version easier to track
+            rustup --version
 
-      # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
-      # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
-      rustup set profile minimal
-      rustup default 1.90.0  # renovate: charmcraft-rust-latest
-      
-      craftctl default
-      # Include requirements.txt in *.charm artifact for easier debugging
-      cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
-  # "files" part name is arbitrary; use for consistency
-  files:
-    plugin: dump
-    source: .
-    after:
-      - poetry-deps  # Ensure poetry is installed
-    build-packages:
-      - git
-    override-build: |
-      craftctl default
-    stage:
-      - LICENSE
+            # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
+            # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
+            rustup set profile minimal
+            rustup default 1.90.0  # renovate: charmcraft-rust-latest
+
+            craftctl default
+            # Include requirements.txt in *.charm artifact for easier debugging
+            cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
+    # "files" part name is arbitrary; use for consistency
+    files:
+        plugin: dump
+        source: .
+        after:
+            - poetry-deps # Ensure poetry is installed
+        build-packages:
+            - git
+        override-build: |
+            craftctl default
+        stage:
+            - LICENSE

--- a/src/literals.py
+++ b/src/literals.py
@@ -10,7 +10,7 @@ CHARM = "valkey"
 CONTAINER = "valkey"
 
 SNAP_NAME = "charmed-valkey"
-SNAP_REVISION = 16
+SNAP_REVISIONS = {"x86_64": 16, "aarch64": 15}
 SNAP_SERVICE = "server"
 SNAP_SENTINEL_SERVICE = "sentinel"
 SNAP_COMMON_PATH = "var/snap/charmed-valkey/common"

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -5,9 +5,10 @@
 """Implementation of WorkloadBase for running Valkey on VMs."""
 
 import logging
+import platform
 import subprocess
 import time
-from typing import List, override
+from typing import override
 
 from charmlibs import pathops, snap
 from tenacity import (
@@ -32,7 +33,7 @@ from literals import (
     SNAP_CONFIG_FILE,
     SNAP_CURRENT_PATH,
     SNAP_NAME,
-    SNAP_REVISION,
+    SNAP_REVISIONS,
     SNAP_SENTINEL_ACL_FILE,
     SNAP_SENTINEL_CONFIG_FILE,
     SNAP_SENTINEL_SERVICE,
@@ -89,11 +90,11 @@ class ValkeyVmWorkload(WorkloadBase):
             True if successfully installed, False if errors occur and `retry_and_raise` is False.
         """
         if not revision:
-            revision = str(SNAP_REVISION)
+            revision = str(SNAP_REVISIONS[platform.machine()])
 
         try:
-            # as long as 26.04 is not stable, we need to install the core26 snap from edge
-            snap.add("core26", channel="edge")
+            # as long as 26.04 is not stable, we need to install the core26 snap from beta
+            snap.add("core26", channel="beta")
 
             self.valkey.ensure(snap.SnapState.Present, revision=revision)
             self.valkey.hold()
@@ -130,7 +131,7 @@ class ValkeyVmWorkload(WorkloadBase):
             ) from e
 
     @override
-    def exec(self, command: List[str]) -> tuple[str, str | None]:
+    def exec(self, command: list[str]) -> tuple[str, str | None]:
         try:
             output = subprocess.run(
                 command,

--- a/tests/integration/clients/requirer-charm/charmcraft.yaml
+++ b/tests/integration/clients/requirer-charm/charmcraft.yaml
@@ -1,11 +1,11 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
 type: charm
 
 platforms:
   ubuntu@24.04:amd64:
+  ubuntu@24.04:arm64:
 
 parts:
   # "poetry-deps" part name is a magic constant
@@ -45,11 +45,11 @@ parts:
     source: .
     after:
       - poetry-deps
-    poetry-export-extra-args: ['--without-hashes']
+    poetry-export-extra-args: ["--without-hashes"]
     build-packages:
-      - libffi-dev  # Needed to build Python dependencies with Rust from source
-      - libssl-dev  # Needed to build Python dependencies with Rust from source
-      - pkg-config  # Needed to build Python dependencies with Rust from source
+      - libffi-dev # Needed to build Python dependencies with Rust from source
+      - libssl-dev # Needed to build Python dependencies with Rust from source
+      - pkg-config # Needed to build Python dependencies with Rust from source
       - libprotobuf-dev # Needed to build Valkey-glide
       - protobuf-compiler # Needed to build Valkey-glide
       - git


### PR DESCRIPTION
This pull request introduces architecture-specific improvements and minor configuration updates to support ARM64 alongside x86_64, and refines how snap revisions are managed for different platforms. The changes also update the snap installation process and make minor code cleanups.

**Platform and Architecture Support:**

* Added ARM64 (`arm64`) as a supported platform in `charmcraft.yaml` to enable testing and deployment on ARM-based systems.

**Snap Revision Handling:**

* Changed `SNAP_REVISION` to `SNAP_REVISIONS`, a dictionary mapping architecture names to their respective snap revisions in `src/literals.py`, and updated all references to use the correct revision based on the current machine architecture. [[1]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64L13-R13) [[2]](diffhunk://#diff-c8d821aa95dccb00788f23b52ba855b1535407b87c9c13ea9a903ececf1748deL35-R36) [[3]](diffhunk://#diff-c8d821aa95dccb00788f23b52ba855b1535407b87c9c13ea9a903ececf1748deL92-R97)

**Snap Installation Process:**

* Updated the snap installation channel for `core26` from `edge` to `beta` to reflect the current recommended channel.

**Configuration and Code Cleanups:**

* Reformatted the `poetry-export-extra-args` section in `charmcraft.yaml` for better readability.
* Minor type annotation update in `src/workload_vm.py` for the `exec` method to use `list[str]` instead of `List[str]`.
* Added missing `import platform` in `src/workload_vm.py` for architecture detection.