### PR TITLE
patch: update rock in metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ in Juju. For details, see [development setup](https://documentation.ubuntu.com/j
 
 In our case, we want to deploy `valkey` to a model `test` on a Kubernetes cloud. Use the `upstream-source` from `metadata.yaml`:
 ```shell
-$ juju deploy ./valkey_ubuntu@24.04-amd64.charm -n 3 --resource valkey-image=ghcr.io/canonical/valkey:9.0.1-26.04-edge --trust
+$ juju deploy ./valkey_ubuntu@24.04-amd64.charm -n 3 --resource valkey-image=ghcr.io/canonical/charmed-valkey:9.0.1-26.04_edge --trust
 
 $ juju status
 Model    Controller      Cloud/Region        Version  SLA          Timestamp

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,7 +30,7 @@ resources:
   valkey-image:
     type: oci-image
     description: OCI Image for Valkey
-    upstream-source: ghcr.io/canonical/valkey:9.0.1-26.04-edge
+    upstream-source: ghcr.io/canonical/charmed-valkey:9.0.1-26.04_edge
 
 peers:
   valkey-peers:


### PR DESCRIPTION
This pull request updates the upstream source for the `valkey-image` resource in the `metadata.yaml` file. The new source points to a different repository and uses an underscore instead of a hyphen in the tag.

- Resource configuration update:
  * Changed the `valkey-image` resource's `upstream-source` from `ghcr.io/canonical/valkey:9.0.1-26.04-edge` to `ghcr.io/canonical/charmed-valkey:9.0.1-26.04_edge` in `metadata.yaml`, switching to the `charmed-valkey` repository and updating the tag format.
