### PR TITLE
Fix docs link in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ description: |
   Valkey is a flexible distributed key-value database that is optimized 
   for caching and other realtime workloads. This charmed operator deploys 
   and operates Valkey in Kubernetes and VM environments.
-docs: https://canonical-charmed-valkey.readthedocs-hosted.com/en/latest/
+docs: https://canonical-charmed-valkey.readthedocs-hosted.com/latest/
 source: https://github.com/canonical/charmed-valkey-operator
 issues: https://github.com/canonical/charmed-valkey-operator/issues
 website:


### PR DESCRIPTION
The previous link (with `/en/`) leads to a "Page not found" page because the URL schema is configured without languages on Read The Docs.



- [x] Have you updated relevant documentation?
