### PR TITLE
open sentinel ports

### DIFF
--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -27,6 +27,8 @@ from literals import (
     INTERNAL_USERS_PASSWORD_CONFIG,
     INTERNAL_USERS_SECRET_LABEL_SUFFIX,
     PEER_RELATION,
+    SENTINEL_PORT,
+    SENTINEL_TLS_PORT,
     TLS_PORT,
     CharmUsers,
     ScaleDownState,
@@ -216,7 +218,9 @@ class BaseEvents(ops.Object):
 
         if self.charm.state.unit_server.tls_client_state != TLSState.TLS:
             self.charm.unit.open_port("tcp", CLIENT_PORT)
+            self.charm.unit.open_port("tcp", SENTINEL_PORT)
         self.charm.unit.open_port("tcp", TLS_PORT)
+        self.charm.unit.open_port("tcp", SENTINEL_TLS_PORT)
 
         if not self.charm.unit.is_leader():
             return

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -26,6 +26,7 @@ from literals import (
     CLIENT_PORT,
     CLIENT_TLS_RELATION_NAME,
     PEER_RELATION,
+    SENTINEL_PORT,
     TLS_CLIENT_PRIVATE_KEY_CONFIG,
     TLSCARotationState,
     TLSState,
@@ -283,6 +284,7 @@ class TLSEvents(ops.Object):
             self.charm.tls_manager.set_cert_state(is_ready=False)
             self.charm.tls_manager.set_tls_state(TLSState.NO_TLS)
             self.charm.unit.open_port("tcp", CLIENT_PORT)
+            self.charm.unit.open_port("tcp", SENTINEL_PORT)
             self._trigger_relation_change_if_required()
 
         try:


### PR DESCRIPTION
Currently the charm does not open the Sentinel port(s). In order to be able to access Sentinel through the Kubernetes service automatically provisioned by Juju, the charm needs to explicitly open the Sentinel ports:

```
$ kubectl get svc valkey -n valkey -o wide
NAME     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                 AGE     SELECTOR
valkey   ClusterIP   10.152.183.172   <none>        6379/TCP,6380/TCP,26379/TCP,26380/TCP   3m54s   app.kubernetes.io/name=valkey

$ juju ssh valkey/0
# python3
Python 3.12.3 (main, Nov  6 2024, 18:32:19) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from valkey.sentinel import Sentinel
>>> sentinel = Sentinel([("valkey.valkey.svc.cluster.local", 26379)], socket_timeout=0.1, sentinel_kwargs={"username": "charmed-sentinel-operator", "password": "XXX"})
>>> sentinel.discover_master("primary")
('valkey-2.valkey-endpoints', 6380)
```