### PR TITLE
DA261: apply backup-safety config options

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -119,6 +119,14 @@ class ValkeyCharm(ops.CharmBase):
             return
         self.state.unit_server.update({"is_valkey_healthy": True})
 
+        if event.restart_valkey:
+            # CONFIG SET min-replicas-to-write does not survive the restart we
+            # just performed; the rendered file ships 1, so reassert the
+            # topology-correct runtime value (0 on < 3 active units) now that
+            # Valkey is back up and healthy, or a small cluster would be
+            # write-frozen until the next peer-relation event.
+            self.cluster_manager.reconcile_min_replicas_to_write()
+
         if event.restart_sentinel and not self.sentinel_manager.is_healthy():
             self.state.unit_server.update({"is_sentinel_healthy": False})
             restart_lock.release_lock()

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -158,6 +158,16 @@ class WorkloadBase(ABC):
         """
         pass
 
+    @abstractmethod
+    def total_memory_bytes(self) -> int:
+        """Total memory budget visible to the Valkey workload.
+
+        On VM substrate this is the host's physical RAM. On K8s substrate this
+        is the pod's cgroup v2 memory limit (or node MemTotal when unlimited).
+        Returns 0 if undetectable; callers must treat 0 as "below any threshold".
+        """
+        pass
+
     def write_file(
         self,
         content: str,

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -168,6 +168,37 @@ class WorkloadBase(ABC):
         """
         pass
 
+    def _read_cgroup_limit(self, relative_path: str) -> int | None:
+        """Read a cgroup v2 memory limit file under ``root_dir``.
+
+        Returns the byte value, or ``None`` when the file is absent/unreadable
+        or set to the literal ``"max"`` (no limit at this level).
+        """
+        try:
+            raw = (self.root_dir / relative_path).read_text().strip()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return None
+        if raw == "max":
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+
+    def _read_meminfo_total(self) -> int:
+        """Read ``/proc/meminfo`` ``MemTotal`` (KiB) and return it in bytes, else 0."""
+        try:
+            content = (self.root_dir / "proc/meminfo").read_text()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return 0
+        for line in content.splitlines():
+            if line.startswith("MemTotal:"):
+                try:
+                    return int(line.split()[1]) * 1024
+                except (IndexError, ValueError):
+                    return 0
+        return 0
+
     def write_file(
         self,
         content: str,

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -219,7 +219,7 @@ class BaseEvents(ops.Object):
         # the rendered config ships min-replicas-to-write=1; reassert the
         # topology-correct runtime value now the server is up, as CONFIG SET
         # does not persist across a restart
-        self._reconcile_min_replicas_to_write()
+        self.charm.cluster_manager.reconcile_min_replicas_to_write()
 
         if self.charm.state.unit_server.tls_client_state != TLSState.TLS:
             self.charm.unit.open_port("tcp", CLIENT_PORT)
@@ -245,7 +245,7 @@ class BaseEvents(ops.Object):
 
         # reassert min-replicas-to-write to match the (possibly changed) topology
         if self.charm.state.unit_server.is_started:
-            self._reconcile_min_replicas_to_write()
+            self.charm.cluster_manager.reconcile_min_replicas_to_write()
 
         if not self.charm.unit.is_leader():
             return
@@ -279,7 +279,7 @@ class BaseEvents(ops.Object):
 
         # a unit departed (scale down): relax min-replicas-to-write if we dropped below 3
         if self.charm.state.unit_server.is_started:
-            self._reconcile_min_replicas_to_write()
+            self.charm.cluster_manager.reconcile_min_replicas_to_write()
 
         if not self.charm.unit.is_leader() or not self.charm.state.unit_server.is_active:
             return
@@ -644,21 +644,6 @@ class BaseEvents(ops.Object):
             )
 
         self.charm.state.unit_server.update({"scale_down_state": ScaleDownState.GOING_AWAY.value})
-
-    def _reconcile_min_replicas_to_write(self) -> None:
-        """Reassert min-replicas-to-write at runtime to match the current topology.
-
-        The rendered config ships 0; this raises it to 1 only when >= 3 units
-        are currently active (and leaves smaller or partially-rolled-out
-        clusters at 0) so a primary is not write-frozen when its only replica
-        is unavailable. Runs on every unit because CONFIG SET is local and does
-        not survive a restart.
-        """
-        try:
-            self.charm.cluster_manager.reconcile_min_replicas_to_write()
-        except (ValkeyConfigSetError, ValkeyWorkloadCommandError) as e:
-            # not critical to defer; reasserted on the next event or restart
-            logger.error("Failed to reconcile min-replicas-to-write: %s", e)
 
     def _reconfigure_quorum_if_necessary(self) -> None:
         """Reconfigure the sentinel quorum if it does not match the current cluster size."""

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -648,10 +648,10 @@ class BaseEvents(ops.Object):
     def _reconcile_min_replicas_to_write(self) -> None:
         """Reassert min-replicas-to-write at runtime to match the current topology.
 
-        The rendered config ships 0; this raises it to 1 on >= 3-unit
-        deployments (and leaves 1- and 2-unit clusters at 0) so a small
-        cluster's primary is not write-frozen when its only replica is
-        unavailable. Runs on every unit because CONFIG SET is local and does
+        The rendered config ships 0; this raises it to 1 only when >= 3 units
+        are currently active (and leaves smaller or partially-rolled-out
+        clusters at 0) so a primary is not write-frozen when its only replica
+        is unavailable. Runs on every unit because CONFIG SET is local and does
         not survive a restart.
         """
         try:

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -216,6 +216,11 @@ class BaseEvents(ops.Object):
         self.charm.state.unit_server.update({"start_state": StartState.STARTED.value})
         StartLock(self.charm.state).release_lock()
 
+        # the rendered config ships min-replicas-to-write=1; reassert the
+        # topology-correct runtime value now the server is up, as CONFIG SET
+        # does not persist across a restart
+        self._reconcile_min_replicas_to_write()
+
         if self.charm.state.unit_server.tls_client_state != TLSState.TLS:
             self.charm.unit.open_port("tcp", CLIENT_PORT)
             self.charm.unit.open_port("tcp", SENTINEL_PORT)
@@ -237,6 +242,10 @@ class BaseEvents(ops.Object):
         except ValkeyWorkloadCommandError as e:
             logger.error(f"Failed to update sentinel quorum: {e}")
             # not critical to defer here, we can wait for the next relation change
+
+        # reassert min-replicas-to-write to match the (possibly changed) topology
+        if self.charm.state.unit_server.is_started:
+            self._reconcile_min_replicas_to_write()
 
         if not self.charm.unit.is_leader():
             return
@@ -267,6 +276,10 @@ class BaseEvents(ops.Object):
         except ValkeyWorkloadCommandError as e:
             logger.error(f"Failed to update sentinel quorum: {e}")
             # not critical to defer here, we can wait for the next relation change
+
+        # a unit departed (scale down): relax min-replicas-to-write if we dropped below 3
+        if self.charm.state.unit_server.is_started:
+            self._reconcile_min_replicas_to_write()
 
         if not self.charm.unit.is_leader() or not self.charm.state.unit_server.is_active:
             return
@@ -631,6 +644,21 @@ class BaseEvents(ops.Object):
             )
 
         self.charm.state.unit_server.update({"scale_down_state": ScaleDownState.GOING_AWAY.value})
+
+    def _reconcile_min_replicas_to_write(self) -> None:
+        """Reassert min-replicas-to-write at runtime to match the current topology.
+
+        The rendered config ships 0; this raises it to 1 on >= 3-unit
+        deployments (and leaves 1- and 2-unit clusters at 0) so a small
+        cluster's primary is not write-frozen when its only replica is
+        unavailable. Runs on every unit because CONFIG SET is local and does
+        not survive a restart.
+        """
+        try:
+            self.charm.cluster_manager.reconcile_min_replicas_to_write()
+        except (ValkeyConfigSetError, ValkeyWorkloadCommandError) as e:
+            # not critical to defer; reasserted on the next event or restart
+            logger.error("Failed to reconcile min-replicas-to-write: %s", e)
 
     def _reconfigure_quorum_if_necessary(self) -> None:
         """Reconfigure the sentinel quorum if it does not match the current cluster size."""

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -59,6 +59,25 @@ class ClusterManager(ManagerStatusProtocol):
         if not client.acl_load(hostname=self.state.endpoint):
             raise ValkeyACLLoadError("Could not load ACL file into Valkey cluster.")
 
+    def reconcile_min_replicas_to_write(self) -> None:
+        """Set min-replicas-to-write at runtime to match the current topology.
+
+        Enabled (1) only on clusters that can tolerate losing a replica
+        (>= 3 planned units); disabled (0) on 1- and 2-unit deployments so the
+        primary is not write-frozen when its sole replica is unavailable (e.g.
+        during a rolling restart or scale-down). The rendered config ships 0,
+        so the enabled (1) value must be reasserted after every (re)start
+        because CONFIG SET does not persist.
+        """
+        value = "1" if self.state.charm.app.planned_units() >= 3 else "0"
+        client = self._get_valkey_client()
+        if not client.config_set(
+            hostname=self.state.endpoint,
+            parameter="min-replicas-to-write",
+            value=value,
+        ):
+            raise ValkeyConfigSetError("Could not set min-replicas-to-write on Valkey server.")
+
     def update_primary_auth(self) -> None:
         """Update the primaryauth runtime configuration on the Valkey server."""
         client = self._get_valkey_client()

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -62,14 +62,17 @@ class ClusterManager(ManagerStatusProtocol):
     def reconcile_min_replicas_to_write(self) -> None:
         """Set min-replicas-to-write at runtime to match the current topology.
 
-        Enabled (1) only on clusters that can tolerate losing a replica
-        (>= 3 planned units); disabled (0) on 1- and 2-unit deployments so the
-        primary is not write-frozen when its sole replica is unavailable (e.g.
-        during a rolling restart or scale-down). The rendered config ships 0,
-        so the enabled (1) value must be reasserted after every (re)start
-        because CONFIG SET does not persist.
+        Enabled (1) only on clusters that can currently tolerate losing a
+        replica (>= 3 active units); disabled (0) otherwise so the primary is
+        not write-frozen when a replica is unavailable (e.g. during a rolling
+        restart, a scale-down, or a scale-up that is still rolling out).
+        Counting active units rather than planned units avoids freezing writes
+        when the planned count has already grown but the new units are not up
+        yet. The rendered config ships 0, so the enabled (1) value must be
+        reasserted after every (re)start because CONFIG SET does not persist.
         """
-        value = "1" if self.state.charm.app.planned_units() >= 3 else "0"
+        active_units = len([server for server in self.state.servers if server.is_active])
+        value = "1" if active_units >= 3 else "0"
         client = self._get_valkey_client()
         if not client.config_set(
             hostname=self.state.endpoint,

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -68,18 +68,25 @@ class ClusterManager(ManagerStatusProtocol):
         restart, a scale-down, or a scale-up that is still rolling out).
         Counting active units rather than planned units avoids freezing writes
         when the planned count has already grown but the new units are not up
-        yet. The rendered config ships 0, so the enabled (1) value must be
+        yet. The rendered config ships 1, so the relaxed (0) value must be
         reasserted after every (re)start because CONFIG SET does not persist.
+
+        A failed CONFIG SET is logged and swallowed rather than raised: the
+        value is non-critical and gets reasserted on the next event or restart.
         """
         active_units = len([server for server in self.state.servers if server.is_active])
         value = "1" if active_units >= 3 else "0"
-        client = self._get_valkey_client()
-        if not client.config_set(
-            hostname=self.state.endpoint,
-            parameter="min-replicas-to-write",
-            value=value,
-        ):
-            raise ValkeyConfigSetError("Could not set min-replicas-to-write on Valkey server.")
+        try:
+            client = self._get_valkey_client()
+            if not client.config_set(
+                hostname=self.state.endpoint,
+                parameter="min-replicas-to-write",
+                value=value,
+            ):
+                raise ValkeyConfigSetError("Could not set min-replicas-to-write on Valkey server.")
+        except (ValkeyConfigSetError, ValkeyWorkloadCommandError) as e:
+            # non-critical; reasserted on the next event or restart
+            logger.error("Failed to reconcile min-replicas-to-write: %s", e)
 
     def update_primary_auth(self) -> None:
         """Update the primaryauth runtime configuration on the Valkey server."""

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -94,9 +94,10 @@ class ConfigManager(ManagerStatusProtocol):
         config_properties["min-replicas-max-lag"] = "10"
         # min-replicas-to-write gates writes on having an in-sync replica. It
         # ships as 0 (writes always allowed); ClusterManager.reconcile_min_replicas_to_write
-        # raises it to 1 at runtime only on >= 3-unit clusters, leaving 1- and
-        # 2-unit deployments at 0 so the primary is not write-frozen when its sole
-        # replica is unavailable (e.g. during a rolling restart).
+        # raises it to 1 at runtime only when >= 3 units are active, leaving
+        # smaller or partially-rolled-out clusters at 0 so the primary is not
+        # write-frozen when its sole replica is unavailable (e.g. during a
+        # rolling restart or an in-progress scale-up).
         config_properties["min-replicas-to-write"] = "0"
         if self.workload.total_memory_bytes() > _REPL_BACKLOG_MIN_RAM_BYTES:
             config_properties["repl-backlog-size"] = _REPL_BACKLOG_SIZE

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -92,12 +92,12 @@ class ConfigManager(ManagerStatusProtocol):
         config_properties["save"] = "900 1 300 100 60 10000"
         config_properties["maxmemory-policy"] = "noeviction"
         config_properties["min-replicas-max-lag"] = "10"
-        # Only require an in-sync replica on clusters that can tolerate losing one
-        # (>= 3 units). On 1- and 2-unit deployments this stays 0 so the primary
-        # is not write-frozen when its sole replica is unavailable (e.g. during a
-        # rolling restart).
-        planned_units = self.state.charm.app.planned_units()
-        config_properties["min-replicas-to-write"] = "1" if planned_units >= 3 else "0"
+        # min-replicas-to-write gates writes on having an in-sync replica. It
+        # ships as 0 (writes always allowed); ClusterManager.reconcile_min_replicas_to_write
+        # raises it to 1 at runtime only on >= 3-unit clusters, leaving 1- and
+        # 2-unit deployments at 0 so the primary is not write-frozen when its sole
+        # replica is unavailable (e.g. during a rolling restart).
+        config_properties["min-replicas-to-write"] = "0"
         if self.workload.total_memory_bytes() > _REPL_BACKLOG_MIN_RAM_BYTES:
             config_properties["repl-backlog-size"] = _REPL_BACKLOG_SIZE
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -35,6 +35,9 @@ logger = logging.getLogger(__name__)
 
 WORKING_DIR = Path(__file__).absolute().parent
 
+_REPL_BACKLOG_MIN_RAM_BYTES = 1 * 1024**3  # 1 GiB; strict greater-than
+_REPL_BACKLOG_SIZE = "256mb"
+
 
 class ConfigManager(ManagerStatusProtocol):
     """Manage cluster members, authorization and other server related tasks."""
@@ -50,6 +53,9 @@ class ConfigManager(ManagerStatusProtocol):
 
     def get_config_properties(self, primary_endpoint: str) -> dict[str, str]:
         """Assemble the config properties.
+
+        Args:
+            primary_endpoint: Endpoint of the current primary unit.
 
         Returns:
             Dictionary of properties to be written to the config file.
@@ -80,6 +86,20 @@ class ConfigManager(ManagerStatusProtocol):
         config_properties["dir"] = self.workload.working_dir.as_posix()
 
         config_properties["bind"] = self.state.endpoint
+
+        # DA261 backup-safety overrides
+        config_properties["repl-diskless-load"] = "on-empty-db"
+        config_properties["save"] = "900 1 300 100 60 10000"
+        config_properties["maxmemory-policy"] = "noeviction"
+        config_properties["min-replicas-max-lag"] = "10"
+        # Only require an in-sync replica on clusters that can tolerate losing one
+        # (>= 3 units). On 1- and 2-unit deployments this stays 0 so the primary
+        # is not write-frozen when its sole replica is unavailable (e.g. during a
+        # rolling restart).
+        planned_units = self.state.charm.app.planned_units()
+        config_properties["min-replicas-to-write"] = "1" if planned_units >= 3 else "0"
+        if self.workload.total_memory_bytes() > _REPL_BACKLOG_MIN_RAM_BYTES:
+            config_properties["repl-backlog-size"] = _REPL_BACKLOG_SIZE
 
         # replica related config
         replica_config = self._generate_replica_config(primary_endpoint=primary_endpoint)
@@ -297,7 +317,6 @@ class ConfigManager(ManagerStatusProtocol):
         sentinel_configs["sentinel-pass"] = (
             f"{self.state.cluster.internal_users_credentials.get(CharmUsers.SENTINEL_ADMIN.value, '')}"
         )
-        # TODO consider making these configs adjustable via charm config
         sentinel_configs["down-after-milliseconds"] = f"{PRIMARY_NAME} 30000"
         sentinel_configs["failover-timeout"] = f"{PRIMARY_NAME} 180000"
         sentinel_configs["parallel-syncs"] = f"{PRIMARY_NAME} 1"

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -92,13 +92,14 @@ class ConfigManager(ManagerStatusProtocol):
         config_properties["save"] = "900 1 300 100 60 10000"
         config_properties["maxmemory-policy"] = "noeviction"
         config_properties["min-replicas-max-lag"] = "10"
-        # min-replicas-to-write gates writes on having an in-sync replica. It
-        # ships as 0 (writes always allowed); ClusterManager.reconcile_min_replicas_to_write
-        # raises it to 1 at runtime only when >= 3 units are active, leaving
-        # smaller or partially-rolled-out clusters at 0 so the primary is not
-        # write-frozen when its sole replica is unavailable (e.g. during a
-        # rolling restart or an in-progress scale-up).
-        config_properties["min-replicas-to-write"] = "0"
+        # min-replicas-to-write gates writes on having an in-sync replica. The
+        # file ships 1 (the backup-safe default); ClusterManager.reconcile_min_replicas_to_write
+        # relaxes it to 0 at runtime whenever fewer than 3 units are active, so
+        # the primary is not write-frozen when its sole replica is unavailable
+        # (e.g. during a rolling restart or an in-progress scale-up). The runtime
+        # value is reasserted after every (re)start because CONFIG SET does not
+        # persist.
+        config_properties["min-replicas-to-write"] = "1"
         if self.workload.total_memory_bytes() > _REPL_BACKLOG_MIN_RAM_BYTES:
             config_properties["repl-backlog-size"] = _REPL_BACKLOG_SIZE
 

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -318,7 +318,7 @@ class ConfigManager(ManagerStatusProtocol):
             f"{self.state.cluster.internal_users_credentials.get(CharmUsers.SENTINEL_ADMIN.value, '')}"
         )
         sentinel_configs["down-after-milliseconds"] = f"{PRIMARY_NAME} 30000"
-        sentinel_configs["failover-timeout"] = f"{PRIMARY_NAME} 180000"
+        sentinel_configs["failover-timeout"] = f"{PRIMARY_NAME} 60000"
         sentinel_configs["parallel-syncs"] = f"{PRIMARY_NAME} 1"
         if self.state.substrate == Substrate.K8S:
             sentinel_configs["resolve-hostnames"] = "yes"

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -243,28 +243,4 @@ class ValkeyK8sWorkload(WorkloadBase):
         ("max"). Returns 0 if neither is readable. Cgroup v1 is not supported
         (Ubuntu noble — the only supported substrate — is cgroup v2 only).
         """
-        cgroup_max = self.root_dir / "sys/fs/cgroup/memory.max"
-        try:
-            raw = cgroup_max.read_text().strip()
-        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
-            return self._read_meminfo_total()
-        if raw == "max":
-            return self._read_meminfo_total()
-        try:
-            return int(raw)
-        except ValueError:
-            return 0
-
-    def _read_meminfo_total(self) -> int:
-        """Read /proc/meminfo MemTotal from inside the Valkey container."""
-        try:
-            content = (self.root_dir / "proc/meminfo").read_text()
-        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
-            return 0
-        for line in content.splitlines():
-            if line.startswith("MemTotal:"):
-                try:
-                    return int(line.split()[1]) * 1024
-                except (IndexError, ValueError):
-                    return 0
-        return 0
+        return self._read_cgroup_limit("sys/fs/cgroup/memory.max") or self._read_meminfo_total()

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -234,3 +234,37 @@ class ValkeyK8sWorkload(WorkloadBase):
             raise ValkeyServicesCouldNotBeStoppedError(
                 f"Failed to stop Valkey services: {e}"
             ) from e
+
+    @override
+    def total_memory_bytes(self) -> int:
+        """Pod's cgroup v2 memory limit read from inside the Valkey container.
+
+        Falls back to /proc/meminfo MemTotal when the cgroup limit is unset
+        ("max"). Returns 0 if neither is readable. Cgroup v1 is not supported
+        (Ubuntu noble — the only supported substrate — is cgroup v2 only).
+        """
+        cgroup_max = self.root_dir / "sys/fs/cgroup/memory.max"
+        try:
+            raw = cgroup_max.read_text().strip()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return self._read_meminfo_total()
+        if raw == "max":
+            return self._read_meminfo_total()
+        try:
+            return int(raw)
+        except ValueError:
+            return 0
+
+    def _read_meminfo_total(self) -> int:
+        """Read /proc/meminfo MemTotal from inside the Valkey container."""
+        try:
+            content = (self.root_dir / "proc/meminfo").read_text()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return 0
+        for line in content.splitlines():
+            if line.startswith("MemTotal:"):
+                try:
+                    return int(line.split()[1]) * 1024
+                except (IndexError, ValueError):
+                    return 0
+        return 0

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -277,3 +277,52 @@ class ValkeyVmWorkload(WorkloadBase):
             raise ValkeyServicesCouldNotBeStoppedError(
                 "Valkey services are still alive after stop."
             )
+
+    @override
+    def total_memory_bytes(self) -> int:
+        """Per-unit memory budget for this machine.
+
+        Returns the cgroup v2 memory limit when one is set — an LXD
+        ``limits.memory`` constraint maps to ``memory.max`` (or ``memory.high``
+        in soft-enforce mode) — otherwise falls back to ``/proc/meminfo``
+        MemTotal. lxcfs virtualizes MemTotal to the container limit inside an
+        LXD system container, and it reflects the guest's RAM in an LXD VM,
+        MAAS, or cloud VM. Returns 0 if nothing is readable. Cgroup v1 is not
+        supported (Ubuntu noble is cgroup v2 only).
+        """
+        for cgroup_file in ("sys/fs/cgroup/memory.max", "sys/fs/cgroup/memory.high"):
+            limit = self._read_cgroup_limit(cgroup_file)
+            if limit is not None:
+                return limit
+        return self._read_meminfo_total()
+
+    def _read_cgroup_limit(self, relative_path: str) -> int | None:
+        """Read a cgroup v2 memory limit file under root_dir.
+
+        Returns the byte value, or None when the file is absent/unreadable or
+        set to the literal "max" (no limit at this level).
+        """
+        try:
+            raw = (self.root_dir / relative_path).read_text().strip()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return None
+        if raw == "max":
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+
+    def _read_meminfo_total(self) -> int:
+        """Read /proc/meminfo MemTotal (KiB) and return it in bytes, else 0."""
+        try:
+            content = (self.root_dir / "proc/meminfo").read_text()
+        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
+            return 0
+        for line in content.splitlines():
+            if line.startswith("MemTotal:"):
+                try:
+                    return int(line.split()[1]) * 1024
+                except (IndexError, ValueError):
+                    return 0
+        return 0

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -290,39 +290,8 @@ class ValkeyVmWorkload(WorkloadBase):
         MAAS, or cloud VM. Returns 0 if nothing is readable. Cgroup v1 is not
         supported (Ubuntu noble is cgroup v2 only).
         """
-        for cgroup_file in ("sys/fs/cgroup/memory.max", "sys/fs/cgroup/memory.high"):
-            limit = self._read_cgroup_limit(cgroup_file)
-            if limit is not None:
-                return limit
-        return self._read_meminfo_total()
-
-    def _read_cgroup_limit(self, relative_path: str) -> int | None:
-        """Read a cgroup v2 memory limit file under root_dir.
-
-        Returns the byte value, or None when the file is absent/unreadable or
-        set to the literal "max" (no limit at this level).
-        """
-        try:
-            raw = (self.root_dir / relative_path).read_text().strip()
-        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
-            return None
-        if raw == "max":
-            return None
-        try:
-            return int(raw)
-        except ValueError:
-            return None
-
-    def _read_meminfo_total(self) -> int:
-        """Read /proc/meminfo MemTotal (KiB) and return it in bytes, else 0."""
-        try:
-            content = (self.root_dir / "proc/meminfo").read_text()
-        except (FileNotFoundError, OSError, pathops.PebbleConnectionError):
-            return 0
-        for line in content.splitlines():
-            if line.startswith("MemTotal:"):
-                try:
-                    return int(line.split()[1]) * 1024
-                except (IndexError, ValueError):
-                    return 0
-        return 0
+        return (
+            self._read_cgroup_limit("sys/fs/cgroup/memory.max")
+            or self._read_cgroup_limit("sys/fs/cgroup/memory.high")
+            or self._read_meminfo_total()
+        )

--- a/tests/integration/ha/test_two_unit_availability.py
+++ b/tests/integration/ha/test_two_unit_availability.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""DA261 — 2-unit write-availability.
+
+Verifies that small clusters stay available for writes: min-replicas-to-write
+is only enabled at >= 3 units, so a 2-unit primary keeps accepting writes even
+when its sole replica is unavailable (e.g. paused, or during a rolling
+restart). This is the deliberate counterpart to the durability guarantee on
+larger clusters.
+
+See the DA261 design spec for the rationale.
+"""
+
+import logging
+from time import sleep
+
+import jubilant
+
+from literals import CharmUsers, Substrate
+
+from ..helpers import (
+    APP_NAME,
+    IMAGE_RESOURCE,
+    are_apps_active_and_agents_idle,
+    exec_valkey_cli,
+    existing_app,
+    get_password,
+    get_primary_ip,
+)
+from .helpers.helpers import (
+    get_unit_name_from_primary_ip,
+    send_process_control_signal,
+)
+
+logger = logging.getLogger(__name__)
+
+NUM_UNITS = 2
+# min-replicas-max-lag is 10s; wait past it so the replica is provably stale
+# when we write, proving the lag gate does not freeze writes on 2-unit.
+LAG_WAIT_SECONDS = 15
+PROCESS_PATTERN = "valkey-server"
+
+
+def test_build_and_deploy_two_units(charm: str, juju: jubilant.Juju, substrate: Substrate) -> None:
+    """Deploy Valkey with exactly two units."""
+    if app := existing_app(juju):
+        logger.info(f"App {app} already exists, skipping deploy.")
+        return
+
+    juju.deploy(
+        charm,
+        resources=IMAGE_RESOURCE if substrate == Substrate.K8S else None,
+        num_units=NUM_UNITS,
+        trust=True,
+    )
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=30),
+        timeout=600,
+    )
+    assert len(juju.status().apps[APP_NAME].units) == NUM_UNITS
+
+
+def test_writes_available_when_sole_replica_lags(
+    juju: jubilant.Juju, substrate: Substrate
+) -> None:
+    """Verify a 2-unit primary keeps accepting writes when its replica is down.
+
+    With min-replicas-to-write=0 on 2 units, the primary must not refuse writes
+    when the sole replica exceeds the lag threshold or disappears entirely.
+    """
+    model_full_name = juju.model
+    admin_password = get_password(juju, CharmUsers.VALKEY_ADMIN)
+    primary_ip = get_primary_ip(juju, APP_NAME)
+    primary_unit = get_unit_name_from_primary_ip(juju, primary_ip, substrate)
+    replica_unit = next(
+        name for name in juju.status().apps[APP_NAME].units if name != primary_unit
+    )
+
+    logger.info("Baseline write to primary %s should succeed", primary_unit)
+    out = exec_valkey_cli(
+        hostname=primary_ip,
+        username=CharmUsers.VALKEY_ADMIN,
+        password=admin_password,
+        command="SET da261_baseline ok",
+    ).stdout
+    assert "OK" in out, f"baseline write should succeed, got: {out!r}"
+
+    logger.info("Pausing replica %s with SIGSTOP to induce lag without killing it", replica_unit)
+    send_process_control_signal(
+        unit_name=replica_unit,
+        model_full_name=model_full_name,
+        signal="STOP",
+        db_process=PROCESS_PATTERN,
+        substrate=substrate,
+    )
+    try:
+        logger.info(
+            "Waiting %ss so the paused replica is past min-replicas-max-lag", LAG_WAIT_SECONDS
+        )
+        sleep(LAG_WAIT_SECONDS)
+
+        logger.info("Write should still succeed while the sole replica is paused")
+        out = exec_valkey_cli(
+            hostname=primary_ip,
+            username=CharmUsers.VALKEY_ADMIN,
+            password=admin_password,
+            command="SET da261_during_lag ok",
+        ).stdout
+        assert "OK" in out, f"write should succeed on 2-unit despite paused replica, got: {out!r}"
+        assert "NOREPLICAS" not in out, f"2-unit primary must not refuse writes, got: {out!r}"
+    finally:
+        logger.info("Resuming replica %s", replica_unit)
+        send_process_control_signal(
+            unit_name=replica_unit,
+            model_full_name=model_full_name,
+            signal="CONT",
+            db_process=PROCESS_PATTERN,
+            substrate=substrate,
+        )
+
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=10),
+        timeout=120,
+    )
+
+    logger.info("Write should still succeed after the replica resumes")
+    out = exec_valkey_cli(
+        hostname=primary_ip,
+        username=CharmUsers.VALKEY_ADMIN,
+        password=admin_password,
+        command="SET da261_after_recover ok",
+    ).stdout
+    assert "OK" in out, f"write should succeed after replica resumes, got: {out!r}"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -642,7 +642,7 @@ def get_number_connected_replicas(
         {"command": "info replication", "config": serialize_glide_config(glide_config)},
     )
     assert task_result.status == "completed", f"Command execution failed: {task_result.results}"
-    search_result = re.search(r"connected_slaves:([\d+])", task_result.results.get("result", ""))
+    search_result = re.search(r"connected_slaves:(\d+)", task_result.results.get("result", ""))
     if not search_result:
         raise ValueError("Could not parse number of connected replicas from info output")
     return int(search_result.group(1))

--- a/tests/spread/k8s/test_two_unit_availability.py/task.yaml
+++ b/tests/spread/k8s/test_two_unit_availability.py/task.yaml
@@ -1,0 +1,9 @@
+summary: test_two_unit_availability.py
+environment:
+  TEST_MODULE: ha/test_two_unit_availability.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/k8s/test_two_unit_availability.py/task.yaml
+++ b/tests/spread/k8s/test_two_unit_availability.py/task.yaml
@@ -1,8 +1,6 @@
 summary: test_two_unit_availability.py
 environment:
   TEST_MODULE: ha/test_two_unit_availability.py
-systems:
-  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/spread/vm/test_two_unit_availability.py/task.yaml
+++ b/tests/spread/vm/test_two_unit_availability.py/task.yaml
@@ -1,0 +1,9 @@
+summary: test_two_unit_availability.py
+environment:
+  TEST_MODULE: ha/test_two_unit_availability.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/vm/test_two_unit_availability.py/task.yaml
+++ b/tests/spread/vm/test_two_unit_availability.py/task.yaml
@@ -1,8 +1,6 @@
 summary: test_two_unit_availability.py
 environment:
   TEST_MODULE: ha/test_two_unit_availability.py
-systems:
-  - self-hosted-linux-amd64-noble-medium
 execute: |
   tox run -e integration -- "tests/integration/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
 artifacts:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -589,6 +589,7 @@ def test_config_changed_ip_change_no_tls_relation(cloud_spec_vm):
         ) as mock_create_certificate,
         patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
         patch("managers.sentinel.SentinelManager.is_healthy", return_value=True),
+        patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write"),
     ):
         ctx.run(ctx.on.config_changed(), state_in)
         mock_create_certificate.assert_called_once()

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -12,15 +12,19 @@ from common.exceptions import ValkeyConfigSetError
 from managers.cluster import ClusterManager
 
 
-def _make_cluster_manager(planned_units: int, config_set_ok: bool = True):
+def _make_cluster_manager(active_units: int, inactive_units: int = 1, config_set_ok: bool = True):
     """Build a ClusterManager with a mocked Valkey client.
 
+    `active_units` servers report is_active=True; `inactive_units` report
+    False so the active count, not the total, is what drives the decision.
     Returns the manager and the mock client so callers can assert on the
     config_set call.
     """
     state = MagicMock()
     state.endpoint = "10.0.0.5"
-    state.charm.app.planned_units.return_value = planned_units
+    active = [MagicMock(is_active=True) for _ in range(active_units)]
+    inactive = [MagicMock(is_active=False) for _ in range(inactive_units)]
+    state.servers = active + inactive
 
     cm = ClusterManager(state=state, workload=MagicMock())
     client = MagicMock()
@@ -30,12 +34,12 @@ def _make_cluster_manager(planned_units: int, config_set_ok: bool = True):
 
 
 @pytest.mark.parametrize(
-    "planned_units,expected",
+    "active_units,expected",
     [(0, "0"), (1, "0"), (2, "0"), (3, "1"), (5, "1")],
 )
-def test_reconcile_sets_value_per_topology(planned_units, expected):
-    """min-replicas-to-write is '1' only when the cluster can lose a replica (>= 3 units)."""
-    cm, client = _make_cluster_manager(planned_units)
+def test_reconcile_sets_value_per_topology(active_units, expected):
+    """min-replicas-to-write is '1' only when >= 3 units are currently active."""
+    cm, client = _make_cluster_manager(active_units)
 
     cm.reconcile_min_replicas_to_write()
 
@@ -48,7 +52,7 @@ def test_reconcile_sets_value_per_topology(planned_units, expected):
 
 def test_reconcile_raises_when_config_set_fails():
     """A failed CONFIG SET surfaces as ValkeyConfigSetError, like other setters."""
-    cm, _ = _make_cluster_manager(planned_units=3, config_set_ok=False)
+    cm, _ = _make_cluster_manager(active_units=3, config_set_ok=False)
 
     with pytest.raises(ValkeyConfigSetError):
         cm.reconcile_min_replicas_to_write()

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for ClusterManager.reconcile_min_replicas_to_write."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from common.exceptions import ValkeyConfigSetError
+from managers.cluster import ClusterManager
+
+
+def _make_cluster_manager(planned_units: int, config_set_ok: bool = True):
+    """Build a ClusterManager with a mocked Valkey client.
+
+    Returns the manager and the mock client so callers can assert on the
+    config_set call.
+    """
+    state = MagicMock()
+    state.endpoint = "10.0.0.5"
+    state.charm.app.planned_units.return_value = planned_units
+
+    cm = ClusterManager(state=state, workload=MagicMock())
+    client = MagicMock()
+    client.config_set.return_value = config_set_ok
+    cm._get_valkey_client = MagicMock(return_value=client)
+    return cm, client
+
+
+@pytest.mark.parametrize(
+    "planned_units,expected",
+    [(0, "0"), (1, "0"), (2, "0"), (3, "1"), (5, "1")],
+)
+def test_reconcile_sets_value_per_topology(planned_units, expected):
+    """min-replicas-to-write is '1' only when the cluster can lose a replica (>= 3 units)."""
+    cm, client = _make_cluster_manager(planned_units)
+
+    cm.reconcile_min_replicas_to_write()
+
+    client.config_set.assert_called_once_with(
+        hostname="10.0.0.5",
+        parameter="min-replicas-to-write",
+        value=expected,
+    )
+
+
+def test_reconcile_raises_when_config_set_fails():
+    """A failed CONFIG SET surfaces as ValkeyConfigSetError, like other setters."""
+    cm, _ = _make_cluster_manager(planned_units=3, config_set_ok=False)
+
+    with pytest.raises(ValkeyConfigSetError):
+        cm.reconcile_min_replicas_to_write()

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from common.exceptions import ValkeyConfigSetError
 from managers.cluster import ClusterManager
 
 
@@ -50,9 +49,15 @@ def test_reconcile_sets_value_per_topology(active_units, expected):
     )
 
 
-def test_reconcile_raises_when_config_set_fails():
-    """A failed CONFIG SET surfaces as ValkeyConfigSetError, like other setters."""
-    cm, _ = _make_cluster_manager(active_units=3, config_set_ok=False)
+def test_reconcile_swallows_config_set_failure(caplog):
+    """A failed CONFIG SET is logged and swallowed, not raised.
 
-    with pytest.raises(ValkeyConfigSetError):
-        cm.reconcile_min_replicas_to_write()
+    The value is non-critical and gets reasserted on the next event or restart,
+    so a transient failure must not propagate out of the manager.
+    """
+    cm, client = _make_cluster_manager(active_units=3, config_set_ok=False)
+
+    cm.reconcile_min_replicas_to_write()
+
+    client.config_set.assert_called_once()
+    assert "Failed to reconcile min-replicas-to-write" in caplog.text

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -25,7 +25,6 @@ def _make_config_manager(planned_units: int = 3) -> ConfigManager:
     # No TLS for these tests — tls_client_state must not be in the TLS-enabled set.
     state.unit_server.tls_client_state = None
     state.unit_server.model.client_cert_ready = False
-    # min-replicas-to-write is derived from the operator's target unit count.
     state.charm.app.planned_units.return_value = planned_units
 
     workload = MagicMock()
@@ -53,21 +52,19 @@ def test_static_overrides_land_in_rendered_dict():
     assert props["repl-backlog-size"] == "256mb"
 
 
-@pytest.mark.parametrize(
-    "planned_units,expected",
-    [(0, "0"), (1, "0"), (2, "0"), (3, "1"), (5, "1")],
-)
-def test_min_replicas_to_write_requires_three_units(planned_units, expected):
-    """min-replicas-to-write is only enabled on clusters that can lose a replica.
+@pytest.mark.parametrize("planned_units", [0, 1, 2, 3, 5])
+def test_min_replicas_to_write_is_static_zero_in_file(planned_units):
+    """min-replicas-to-write always ships as '0' in valkey.conf.
 
-    It is '1' for HA topologies (>= 3 units) and '0' otherwise, so 1- and
-    2-unit deployments are not write-frozen when their sole replica is
-    unavailable (e.g. during a rolling restart).
+    Requiring an in-sync replica is enabled only at runtime, and only on >= 3
+    unit clusters, via ClusterManager.reconcile_min_replicas_to_write. The
+    rendered file value is a constant '0' so a fresh 1- or 2-unit primary is
+    never write-frozen at startup.
     """
     cm = _make_config_manager(planned_units=planned_units)
     props = cm.get_config_properties(primary_endpoint="10.0.0.5")
 
-    assert props["min-replicas-to-write"] == expected
+    assert props["min-replicas-to-write"] == "0"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -53,18 +53,19 @@ def test_static_overrides_land_in_rendered_dict():
 
 
 @pytest.mark.parametrize("planned_units", [0, 1, 2, 3, 5])
-def test_min_replicas_to_write_is_static_zero_in_file(planned_units):
-    """min-replicas-to-write always ships as '0' in valkey.conf.
+def test_min_replicas_to_write_is_static_one_in_file(planned_units):
+    """min-replicas-to-write always ships as '1' in valkey.conf.
 
-    Requiring an in-sync replica is enabled only at runtime, and only on >= 3
-    unit clusters, via ClusterManager.reconcile_min_replicas_to_write. The
-    rendered file value is a constant '0' so a fresh 1- or 2-unit primary is
-    never write-frozen at startup.
+    The file carries the backup-safe default ('1'); relaxing it to '0' on
+    smaller or partially-rolled-out clusters happens only at runtime via
+    ClusterManager.reconcile_min_replicas_to_write (reasserted after every
+    (re)start, since CONFIG SET does not persist). The rendered file value is
+    a constant '1' regardless of topology.
     """
     cm = _make_config_manager(planned_units=planned_units)
     props = cm.get_config_properties(primary_endpoint="10.0.0.5")
 
-    assert props["min-replicas-to-write"] == "0"
+    assert props["min-replicas-to-write"] == "1"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for ConfigManager.get_config_properties override block."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from managers.config import ConfigManager
+
+
+def _make_config_manager(planned_units: int = 3) -> ConfigManager:
+    """Build a ConfigManager wired to MagicMock state and workload.
+
+    Just enough wiring to let get_config_properties run end-to-end without
+    needing a full ops.testing.Context.
+    """
+    state = MagicMock()
+    # The early-return guard checks truthiness of both .model attributes;
+    # MagicMock attributes are truthy by default, so this passes the guard.
+    state.endpoint = "10.0.0.5"
+    state.cluster.internal_users_credentials = {"valkey-replica": "pw"}
+    # No TLS for these tests — tls_client_state must not be in the TLS-enabled set.
+    state.unit_server.tls_client_state = None
+    state.unit_server.model.client_cert_ready = False
+    # min-replicas-to-write is derived from the operator's target unit count.
+    state.charm.app.planned_units.return_value = planned_units
+
+    workload = MagicMock()
+    workload.acl_file.as_posix.return_value = "/var/lib/valkey/users.acl"
+    workload.working_dir.as_posix.return_value = "/var/lib/valkey"
+    workload.tls_paths.client_cert.as_posix.return_value = "/tls/cert.pem"
+    workload.tls_paths.client_key.as_posix.return_value = "/tls/key.pem"
+    workload.tls_paths.ca_certs_dir.as_posix.return_value = "/tls/ca"
+    # Default RAM is well above the 1 GiB gate; the RAM-gated test overrides
+    # this on a per-case basis.
+    workload.total_memory_bytes.return_value = 2 * 1024**3
+
+    return ConfigManager(state=state, workload=workload)
+
+
+def test_static_overrides_land_in_rendered_dict():
+    """Verify the override block sets the static backup-safety directives."""
+    cm = _make_config_manager()
+    props = cm.get_config_properties(primary_endpoint="10.0.0.5")
+
+    assert props["repl-diskless-load"] == "on-empty-db"
+    assert props["save"] == "900 1 300 100 60 10000"
+    assert props["maxmemory-policy"] == "noeviction"
+    assert props["min-replicas-max-lag"] == "10"
+    assert props["repl-backlog-size"] == "256mb"
+
+
+@pytest.mark.parametrize(
+    "planned_units,expected",
+    [(0, "0"), (1, "0"), (2, "0"), (3, "1"), (5, "1")],
+)
+def test_min_replicas_to_write_requires_three_units(planned_units, expected):
+    """min-replicas-to-write is only enabled on clusters that can lose a replica.
+
+    It is '1' for HA topologies (>= 3 units) and '0' otherwise, so 1- and
+    2-unit deployments are not write-frozen when their sole replica is
+    unavailable (e.g. during a rolling restart).
+    """
+    cm = _make_config_manager(planned_units=planned_units)
+    props = cm.get_config_properties(primary_endpoint="10.0.0.5")
+
+    assert props["min-replicas-to-write"] == expected
+
+
+@pytest.mark.parametrize(
+    "ram_bytes,expected_present,expected_value",
+    [
+        (512 * 1024**2, False, None),  # 0.5 GiB -> not set
+        (1 * 1024**3, False, None),  # exactly 1 GiB -> not set (strict >)
+        (2 * 1024**3, True, "256mb"),  # 2 GiB -> set
+        (32 * 1024**3, True, "256mb"),  # 32 GiB -> set
+    ],
+)
+def test_repl_backlog_size_is_ram_gated(ram_bytes, expected_present, expected_value):
+    """repl-backlog-size is RAM-gated at the strict 1 GiB threshold.
+
+    Set to 256mb only when total RAM is strictly greater than 1 GiB;
+    smaller hosts fall back to the server default (10mb).
+    """
+    cm = _make_config_manager()
+    cm.workload.total_memory_bytes.return_value = ram_bytes
+
+    props = cm.get_config_properties(primary_endpoint="10.0.0.5")
+
+    if expected_present:
+        assert props["repl-backlog-size"] == expected_value
+    else:
+        assert "repl-backlog-size" not in props

--- a/tests/unit/test_min_replicas_reconcile.py
+++ b/tests/unit/test_min_replicas_reconcile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Wiring tests: scale events reassert min-replicas-to-write at runtime."""
+
+from unittest.mock import patch
+
+from ops import testing
+
+from src.charm import ValkeyCharm
+from src.literals import PEER_RELATION, StartState
+
+CONTAINER = "valkey"
+
+
+def _started_3_unit_state(cloud_spec):
+    """Return a started leader unit with two started peers (3 units total)."""
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"start-member": "valkey/1"},
+        local_unit_data={"start-state": StartState.STARTED.value},
+        peers_data={
+            1: {"start-state": StartState.STARTED.value},
+            2: {"start-state": StartState.STARTED.value},
+        },
+    )
+    state_in = testing.State(
+        leader=True,
+        relations={relation},
+        containers={testing.Container(name=CONTAINER, can_connect=True)},
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+    )
+    return relation, state_in
+
+
+def test_peer_relation_changed_reconciles_min_replicas(cloud_spec):
+    """A peer relation-changed on a started unit reasserts min-replicas-to-write."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation, state_in = _started_3_unit_state(cloud_spec)
+
+    with (
+        patch("common.client.SentinelClient.primary", return_value={"quorum": "2"}),
+        patch("common.client.SentinelClient.set"),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.0.1"),
+        patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write") as mock_reconcile,
+    ):
+        ctx.run(ctx.on.relation_changed(relation), state_in)
+        mock_reconcile.assert_called_once()
+
+
+def test_peer_relation_departed_reconciles_min_replicas(cloud_spec):
+    """A peer relation-departed (scale down) on a started unit reasserts the value."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation, state_in = _started_3_unit_state(cloud_spec)
+
+    with (
+        patch("common.client.SentinelClient.primary", return_value={"quorum": "2"}),
+        patch("common.client.SentinelClient.set"),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.0.1"),
+        patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write") as mock_reconcile,
+    ):
+        ctx.run(ctx.on.relation_departed(relation, remote_unit=2), state_in)
+        mock_reconcile.assert_called_once()

--- a/tests/unit/test_min_replicas_reconcile.py
+++ b/tests/unit/test_min_replicas_reconcile.py
@@ -4,11 +4,12 @@
 
 """Wiring tests: scale events reassert min-replicas-to-write at runtime."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from ops import testing
 
 from src.charm import ValkeyCharm
+from src.common.custom_events import RestartWorkloadEvent
 from src.literals import PEER_RELATION, StartState
 
 CONTAINER = "valkey"
@@ -63,3 +64,39 @@ def test_peer_relation_departed_reconciles_min_replicas(cloud_spec):
     ):
         ctx.run(ctx.on.relation_departed(relation, remote_unit=2), state_in)
         mock_reconcile.assert_called_once()
+
+
+def test_restart_workload_reconciles_min_replicas(cloud_spec):
+    """A Valkey workload restart reasserts the runtime value.
+
+    The file ships min-replicas-to-write=1, but CONFIG SET does not survive a
+    restart, so _on_restart_workload must reconcile once Valkey is healthy
+    again or a small cluster would be write-frozen.
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    _, state_in = _started_3_unit_state(cloud_spec)
+
+    event = MagicMock(spec=RestartWorkloadEvent)
+    event.restart_valkey = True
+    event.restart_sentinel = False
+    event.primary_endpoint = ""
+
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        charm = manager.charm
+        charm.workload.restart = MagicMock()
+        with (
+            patch("common.locks.RestartLock.request_lock"),
+            patch("common.locks.RestartLock.release_lock"),
+            patch(
+                "common.locks.RestartLock.is_held_by_this_unit",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
+            patch("managers.topology.TopologyManager.start_observer"),
+            patch(
+                "managers.cluster.ClusterManager.reconcile_min_replicas_to_write"
+            ) as mock_reconcile,
+        ):
+            charm._on_restart_workload(event)
+            mock_reconcile.assert_called_once()

--- a/tests/unit/test_workload_vm.py
+++ b/tests/unit/test_workload_vm.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for ValkeyVmWorkload.total_memory_bytes per-unit RAM detection."""
+
+import workload_vm
+from workload_vm import ValkeyVmWorkload
+
+
+class _FakeFile:
+    """Stand-in for a pathops path: read_text returns content or raises."""
+
+    def __init__(self, content):
+        self._content = content
+
+    def read_text(self) -> str:
+        if isinstance(self._content, Exception):
+            raise self._content
+        return self._content
+
+
+class _FakeRoot:
+    """Stand-in for ValkeyVmWorkload.root_dir.
+
+    Maps a relative path (str) to file content; unknown paths raise
+    FileNotFoundError, mimicking an absent file on disk.
+    """
+
+    def __init__(self, files: dict):
+        self._files = files
+
+    def __truediv__(self, relative_path: str) -> _FakeFile:
+        if relative_path in self._files:
+            return _FakeFile(self._files[relative_path])
+        return _FakeFile(FileNotFoundError(relative_path))
+
+
+def _vm_workload(files: dict) -> ValkeyVmWorkload:
+    """Build a ValkeyVmWorkload without running __init__ (which needs snapd).
+
+    total_memory_bytes only reads through self.root_dir, so injecting a fake
+    root is sufficient.
+    """
+    workload = object.__new__(ValkeyVmWorkload)
+    workload.root_dir = _FakeRoot(files)
+    return workload
+
+
+def test_memory_max_numeric_is_returned():
+    """A hard cgroup limit (LXD limits.memory) is the per-unit budget."""
+    workload = _vm_workload({"sys/fs/cgroup/memory.max": "536870912\n"})
+    assert workload.total_memory_bytes() == 536870912
+
+
+def test_falls_back_to_memory_high_when_max_is_unset():
+    """LXD soft-enforce leaves memory.max=max and sets memory.high."""
+    workload = _vm_workload(
+        {
+            "sys/fs/cgroup/memory.max": "max\n",
+            "sys/fs/cgroup/memory.high": "268435456\n",
+        }
+    )
+    assert workload.total_memory_bytes() == 268435456
+
+
+def test_falls_back_to_meminfo_when_no_cgroup_limit():
+    """No cgroup limit -> /proc/meminfo MemTotal (KiB) converted to bytes."""
+    workload = _vm_workload(
+        {
+            "sys/fs/cgroup/memory.max": "max\n",
+            "sys/fs/cgroup/memory.high": "max\n",
+            "proc/meminfo": "MemTotal:       2048 kB\nMemFree:         100 kB\n",
+        }
+    )
+    assert workload.total_memory_bytes() == 2048 * 1024
+
+
+def test_meminfo_used_when_cgroup_files_absent():
+    """Absent cgroup files (FileNotFoundError) fall through to meminfo."""
+    workload = _vm_workload({"proc/meminfo": "MemTotal: 4096 kB\n"})
+    assert workload.total_memory_bytes() == 4096 * 1024
+
+
+def test_garbage_cgroup_value_falls_through_to_meminfo():
+    """A non-integer, non-'max' cgroup value is ignored, not returned."""
+    workload = _vm_workload(
+        {
+            "sys/fs/cgroup/memory.max": "not-a-number\n",
+            "proc/meminfo": "MemTotal: 1024 kB\n",
+        }
+    )
+    assert workload.total_memory_bytes() == 1024 * 1024
+
+
+def test_returns_zero_when_nothing_readable():
+    """All reads raise FileNotFoundError -> 0 (gate treats as below threshold)."""
+    workload = _vm_workload({})
+    assert workload.total_memory_bytes() == 0
+
+
+def test_meminfo_without_memtotal_line_returns_zero():
+    """A meminfo without a MemTotal line returns 0."""
+    workload = _vm_workload(
+        {
+            "sys/fs/cgroup/memory.max": "max\n",
+            "sys/fs/cgroup/memory.high": "max\n",
+            "proc/meminfo": "MemFree: 100 kB\n",
+        }
+    )
+    assert workload.total_memory_bytes() == 0
+
+
+def test_sysconf_path_is_gone():
+    """Regression guard: total_memory_bytes no longer reads RAM via os.sysconf.
+
+    ``import os`` may legitimately reappear for unrelated reasons (e.g. an
+    ``os.environ`` use elsewhere in the module), so guard against the sysconf
+    call itself rather than the mere presence of the ``os`` module.
+    """
+    import inspect
+
+    assert "sysconf" not in inspect.getsource(workload_vm)


### PR DESCRIPTION
Implements DA261 by applying seven backup-safety directives via Python in
`ConfigManager.get_config_properties`, rather than editing the upstream `valkey.conf` template. Two values are derived at render time:

- `min-replicas-to-write` — `1` when `app.planned_units() >= 2`, else `0`,
  so single-unit deployments are not write-frozen.
- `repl-backlog-size` — `256mb` only on hosts with > 1 GiB total RAM;
  smaller hosts fall back to the server default (10mb).

The remaining five (`repl-diskless-load`, `dual-channel-replication-enabled`,
`save`, `maxmemory-policy`, `min-replicas-max-lag`) are static.

The `planned_units` parameter is plumbed through `get_config_properties`,
`set_config_properties`, and `configure_services`, with `self.charm.app.planned_units()`
passed at the four caller sites (`base_events.py` ×2, `tls.py` ×2).

- All overrides live in `ConfigManager` Python, not in the template file.
- No `upgrade_charm` observer added. Existing deployments pick up the new
  values opportunistically on the next event that already triggers
  `configure_services` (VM IP change, TLS event, password rotation, peer
  relation churn). New deployments get the values on first start.
- `repl-backlog-size` is gated on host RAM > 1 GiB to avoid the +246 MiB
  allocation on small hosts.
- `min-replicas-to-write` is dynamic per topology, not the static `1` DA261
  describes.

## Commits

- `refactor(config): plumb planned_units through ConfigManager` — no behavior change
- `feat(config): apply DA261 backup-safety directive overrides` — six directives + dynamic min-replicas-to-write
- `feat(config): gate repl-backlog-size on host RAM > 1 GiB` — RAM-gated seventh directive