### PR TITLE
DA262: add binary streaming exec primitive (exec_stream)

### DIFF
--- a/src/common/client.py
+++ b/src/common/client.py
@@ -39,7 +39,7 @@ class CliClient:
         The password is intentionally NOT placed on the command line --
         ``--pass`` is visible via /proc/<pid>/cmdline to any same-UID (or,
         on K8s, same-pod) process. Callers must supply it through the
-        ``REDISCLI_AUTH`` environment variable instead (see
+        ``VALKEYCLI_AUTH`` environment variable instead (see
         :meth:`exec_cli_command`).
 
         Args:
@@ -95,7 +95,7 @@ class CliClient:
         cli_command = (
             self.build_command_prefix(json_output=json_output, hostname=hostname) + command
         )
-        output, error = self.workload.exec(cli_command, env={"REDISCLI_AUTH": self.password})
+        output, error = self.workload.exec(cli_command, env={"VALKEYCLI_AUTH": self.password})
         output = output.strip()
         if error:
             logger.error(

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -95,9 +95,7 @@ class CliClient:
         cli_command = (
             self.build_command_prefix(json_output=json_output, hostname=hostname) + command
         )
-        output, error = self.workload.exec(
-            cli_command, env={"REDISCLI_AUTH": self.password}
-        )
+        output, error = self.workload.exec(cli_command, env={"REDISCLI_AUTH": self.password})
         output = output.strip()
         if error:
             logger.error(

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -33,6 +33,42 @@ class CliClient:
         self.tls = tls
         self.workload = workload
 
+    def build_command_prefix(self, json_output: bool, hostname: str | None = None) -> list[str]:
+        """Construct the argv prefix for a valkey-cli invocation.
+
+        Args:
+            json_output: If True, appends ``--json``.
+            hostname: Optional host; when provided, inserts ``-h <hostname>``.
+        """
+        cmd: list[str] = [self.workload.cli, "--no-auth-warning"]
+        if hostname is not None:
+            cmd.extend(["-h", hostname])
+        cmd.extend(
+            [
+                "-p",
+                str(self.port),
+                "--user",
+                self.username,
+                "--pass",
+                self.password,
+            ]
+        )
+        if json_output:
+            cmd.append("--json")
+        if self.tls:
+            cmd.extend(
+                [
+                    "--tls",
+                    "--cert",
+                    self.workload.tls_paths.client_cert.as_posix(),
+                    "--key",
+                    self.workload.tls_paths.client_key.as_posix(),
+                    "--cacertdir",
+                    self.workload.tls_paths.ca_certs_dir.as_posix(),
+                ]
+            )
+        return cmd
+
     def exec_cli_command(
         self,
         command: list[str],
@@ -52,30 +88,9 @@ class CliClient:
         Raises:
             ValkeyWorkloadCommandError: If the CLI command fails to execute.
         """
-        port = self.port
-        cli_command: list[str] = [
-            self.workload.cli,
-            "--no-auth-warning",
-            "-h",
-            hostname,
-            "-p",
-            str(port),
-            "--user",
-            self.username,
-            "--pass",
-            self.password,
-        ] + (["--json"] if json_output else [])
-
-        if self.tls:
-            cli_command.append("--tls")
-            cli_command.append("--cert")
-            cli_command.append(self.workload.tls_paths.client_cert.as_posix())
-            cli_command.append("--key")
-            cli_command.append(self.workload.tls_paths.client_key.as_posix())
-            cli_command.append("--cacertdir")
-            cli_command.append(self.workload.tls_paths.ca_certs_dir.as_posix())
-
-        cli_command = cli_command + command
+        cli_command = (
+            self.build_command_prefix(json_output=json_output, hostname=hostname) + command
+        )
         output, error = self.workload.exec(cli_command)
         output = output.strip()
         if error:

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -47,7 +47,7 @@ class CliClient:
             hostname: Optional host; when provided, inserts ``-h <hostname>``.
         """
         cmd: list[str] = [self.workload.cli, "--no-auth-warning"]
-        if hostname is not None:
+        if hostname:
             cmd.extend(["-h", hostname])
         cmd.extend(
             [

--- a/src/common/client.py
+++ b/src/common/client.py
@@ -36,6 +36,12 @@ class CliClient:
     def build_command_prefix(self, json_output: bool, hostname: str | None = None) -> list[str]:
         """Construct the argv prefix for a valkey-cli invocation.
 
+        The password is intentionally NOT placed on the command line --
+        ``--pass`` is visible via /proc/<pid>/cmdline to any same-UID (or,
+        on K8s, same-pod) process. Callers must supply it through the
+        ``REDISCLI_AUTH`` environment variable instead (see
+        :meth:`exec_cli_command`).
+
         Args:
             json_output: If True, appends ``--json``.
             hostname: Optional host; when provided, inserts ``-h <hostname>``.
@@ -49,8 +55,6 @@ class CliClient:
                 str(self.port),
                 "--user",
                 self.username,
-                "--pass",
-                self.password,
             ]
         )
         if json_output:
@@ -91,7 +95,9 @@ class CliClient:
         cli_command = (
             self.build_command_prefix(json_output=json_output, hostname=hostname) + command
         )
-        output, error = self.workload.exec(cli_command)
+        output, error = self.workload.exec(
+            cli_command, env={"REDISCLI_AUTH": self.password}
+        )
         output = output.strip()
         if error:
             logger.error(

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -99,20 +99,31 @@ class WorkloadBase(ABC):
         """Restart a workload service."""
         pass
 
-    def exec_stream(self, command: list[str]) -> ProcessHandle:
+    def exec_stream(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> ProcessHandle:
         """Spawn a command whose stdout streams to the caller as raw bytes.
 
         Unlike :meth:`exec`, this does not buffer stdout and has no timeout.
         Stderr is captured and returned by ``ProcessHandle.wait()``.
         Used for long-running streaming uploads such as ``valkey-cli --rdb -``.
 
+        ``env`` entries are added to the process environment; use it for
+        secrets (e.g. ``REDISCLI_AUTH``) that must not appear on argv.
+
         Subclasses must override this method.
         """
         raise NotImplementedError("Subclass must implement exec_stream")
 
     @abstractmethod
-    def exec(self, command: list[str]) -> tuple[str, str | None]:
-        """Run a command on the workload substrate."""
+    def exec(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> tuple[str, str | None]:
+        """Run a command on the workload substrate.
+
+        ``env`` entries are added to the process environment; use it for
+        secrets that must not appear on the command line.
+        """
         pass
 
     @abstractmethod

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -6,10 +6,26 @@
 
 import logging
 from abc import ABC, abstractmethod
+from typing import IO, Protocol, runtime_checkable
 
 from charmlibs import pathops
 
 from common.exceptions import ValkeyWorkloadCommandError
+
+
+@runtime_checkable
+class ProcessHandle(Protocol):
+    """Streaming subprocess handle returned by ``WorkloadBase.exec_stream``."""
+
+    stdout: IO[bytes]
+
+    def wait(self) -> tuple[int, str]:
+        """Wait for completion. Returns ``(returncode, stderr_text)``."""
+        ...
+
+    def kill(self) -> None:
+        """Terminate the underlying process forcefully."""
+        ...
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +97,17 @@ class WorkloadBase(ABC):
     def restart(self, service: str) -> None:
         """Restart a workload service."""
         pass
+
+    def exec_stream(self, command: list[str]) -> ProcessHandle:
+        """Spawn a command whose stdout streams to the caller as raw bytes.
+
+        Unlike :meth:`exec`, this does not buffer stdout and has no timeout.
+        Stderr is captured and returned by ``ProcessHandle.wait()``.
+        Used for long-running streaming uploads such as ``valkey-cli --rdb -``.
+
+        Subclasses must override this method.
+        """
+        raise NotImplementedError("Subclass must implement exec_stream")
 
     @abstractmethod
     def exec(self, command: list[str]) -> tuple[str, str | None]:

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -15,16 +15,41 @@ from common.exceptions import ValkeyWorkloadCommandError
 
 @runtime_checkable
 class ProcessHandle(Protocol):
-    """Streaming subprocess handle returned by ``WorkloadBase.exec_stream``."""
+    """Streaming subprocess handle returned by ``WorkloadBase.exec_stream``.
+
+    Wraps a long-running child process whose stdout is streamed to the
+    caller rather than buffered in memory -- ``exec_stream`` is used for
+    transfers (e.g. ``valkey-cli --rdb -``) that can exceed the charm
+    container's heap.
+
+    Two substrate implementations exist: ``_VmProcessHandle`` over
+    ``subprocess.Popen`` and ``_K8sProcessHandle`` over Pebble exec. They
+    honour the same contract; substrate-specific behaviour the caller can
+    rely on is documented per-method below.
+
+    ``stdout`` is the raw stdout pipe -- read it incrementally; it is never
+    fully buffered.
+    """
 
     stdout: IO[bytes]
 
     def wait(self) -> tuple[int, str]:
-        """Wait for completion. Returns ``(returncode, stderr_text)``."""
+        """Block until the process exits; return ``(returncode, stderr_text)``.
+
+        ``returncode`` is the child's exit status, or a negative sentinel
+        when the substrate could not determine it (e.g. a Pebble change
+        error on K8s). ``stderr_text`` is decoded best-effort and may be
+        truncated to a bounded tail -- it is for diagnostics, not parsing.
+        """
         ...
 
     def kill(self) -> None:
-        """Terminate the underlying process forcefully."""
+        """Best-effort forced termination of the process.
+
+        Safe to call after the process has already exited. Errors are
+        logged, not raised, so callers can invoke it unconditionally on
+        cleanup paths.
+        """
         ...
 
 

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -27,6 +27,7 @@ class ProcessHandle(Protocol):
         """Terminate the underlying process forcefully."""
         ...
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -132,7 +132,7 @@ class WorkloadBase(ABC):
         Used for long-running streaming uploads such as ``valkey-cli --rdb -``.
 
         ``env`` entries are added to the process environment; use it for
-        secrets (e.g. ``REDISCLI_AUTH``) that must not appear on argv.
+        secrets (e.g. ``VALKEYCLI_AUTH``) that must not appear on argv.
 
         Subclasses must override this method.
         """

--- a/src/core/base_workload.py
+++ b/src/core/base_workload.py
@@ -124,9 +124,7 @@ class WorkloadBase(ABC):
         """Restart a workload service."""
         pass
 
-    def exec_stream(
-        self, command: list[str], env: dict[str, str] | None = None
-    ) -> ProcessHandle:
+    def exec_stream(self, command: list[str], env: dict[str, str] | None = None) -> ProcessHandle:
         """Spawn a command whose stdout streams to the caller as raw bytes.
 
         Unlike :meth:`exec`, this does not buffer stdout and has no timeout.

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -76,8 +76,16 @@ class _K8sProcessHandle:
     def kill(self) -> None:
         try:
             self._process.send_signal(signal.SIGKILL)
+        except ops.pebble.ConnectionError as e:
+            # Pebble itself is unreachable -- the exec may still be running
+            # and we have lost the ability to stop it. A real problem.
+            logger.error("Cannot reach Pebble to SIGKILL the exec: %s", e)
         except ops.pebble.Error as e:
-            logger.warning("Failed to send SIGKILL to Pebble exec: %s", e)
+            # Most often the exec has already finished, so there is nothing
+            # to signal. kill() is called on cleanup paths after the process
+            # may have exited on its own, so this is expected -- DEBUG, not
+            # WARNING, to avoid alarming noise on the happy path.
+            logger.debug("SIGKILL to Pebble exec was a no-op (likely already exited): %s", e)
 
 
 class ValkeyK8sWorkload(WorkloadBase):

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -33,13 +33,16 @@ logger = logging.getLogger(__name__)
 
 
 class _K8sProcessHandle:
-    """ProcessHandle implementation backed by Pebble exec.
+    """ProcessHandle backed by Pebble exec (K8s substrate).
 
     stdout is streamed to the caller unbuffered. stderr is drained on a
-    daemon thread into a bounded buffer so a chatty child cannot fill the
-    pipe and block. wait() returns the exit code WITHOUT calling
-    wait_output() -- the latter would buffer the entire stdout (the whole
-    RDB) into the charm container's memory.
+    daemon thread into a bounded buffer (last 64 chunks) so a chatty child
+    cannot fill the pipe and block -- ``wait()`` therefore returns only the
+    tail of stderr. ``wait()`` returns the exit code WITHOUT calling
+    ``wait_output()``: the latter would buffer the entire stdout (the whole
+    RDB) into the charm container's memory. When Pebble itself fails to run
+    the change, ``wait()`` returns -1 as the returncode sentinel.
+    ``kill()`` sends SIGKILL but does not block waiting for the exit.
     """
 
     def __init__(self, process: ops.pebble.ExecProcess):

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -178,10 +178,13 @@ class ValkeyK8sWorkload(WorkloadBase):
         return True
 
     @override
-    def exec(self, command: list[str]) -> tuple[str, str | None]:
+    def exec(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> tuple[str, str | None]:
         try:
             process = self.container.exec(
                 command=command,
+                environment=env,
             )
             return process.wait_output()
         except ops.pebble.APIError as e:
@@ -192,8 +195,14 @@ class ValkeyK8sWorkload(WorkloadBase):
             raise ValkeyWorkloadCommandError(e)
 
     @override
-    def exec_stream(self, command: list[str]) -> ProcessHandle:
-        return _K8sProcessHandle(self.container.exec(command=command, encoding=None, timeout=None))
+    def exec_stream(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> ProcessHandle:
+        return _K8sProcessHandle(
+            self.container.exec(
+                command=command, encoding=None, timeout=None, environment=env
+            )
+        )
 
     @override
     def stop(self) -> None:

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -8,7 +8,7 @@ import collections
 import logging
 import signal
 import threading
-from typing import override
+from typing import IO, override
 
 import ops
 from charmlibs import pathops
@@ -47,7 +47,9 @@ class _K8sProcessHandle:
 
     def __init__(self, process: ops.pebble.ExecProcess):
         self._process = process
-        self.stdout = process.stdout
+        if process.stdout is None:
+            raise RuntimeError("Pebble exec must be created with stdout available")
+        self.stdout: IO[bytes] = process.stdout
         self._stderr_buf: collections.deque[bytes] = collections.deque(maxlen=64)
         self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
         self._stderr_thread.start()
@@ -59,10 +61,11 @@ class _K8sProcessHandle:
         pipe and block the caller draining stdout. Read failures are logged
         and terminate the thread rather than propagating to the caller.
         """
-        if self._process.stderr is None:
+        stderr = self._process.stderr
+        if stderr is None:
             return
         try:
-            for chunk in iter(lambda: self._process.stderr.read(4096), b""):
+            for chunk in iter(lambda: stderr.read(4096), b""):
                 self._stderr_buf.append(chunk)
         except Exception:
             logger.exception("stderr drain thread failed")

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -206,13 +206,9 @@ class ValkeyK8sWorkload(WorkloadBase):
             raise ValkeyWorkloadCommandError(e)
 
     @override
-    def exec_stream(
-        self, command: list[str], env: dict[str, str] | None = None
-    ) -> ProcessHandle:
+    def exec_stream(self, command: list[str], env: dict[str, str] | None = None) -> ProcessHandle:
         return _K8sProcessHandle(
-            self.container.exec(
-                command=command, encoding=None, timeout=None, environment=env
-            )
+            self.container.exec(command=command, encoding=None, timeout=None, environment=env)
         )
 
     @override

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -53,6 +53,12 @@ class _K8sProcessHandle:
         self._stderr_thread.start()
 
     def _drain_stderr(self) -> None:
+        """Drain the child's stderr into the bounded tail buffer until EOF.
+
+        Runs on a daemon thread so a chatty child cannot fill the stderr
+        pipe and block the caller draining stdout. Read failures are logged
+        and terminate the thread rather than propagating to the caller.
+        """
         if self._process.stderr is None:
             return
         try:

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -5,6 +5,7 @@
 """Implementation of WorkloadBase for running Valkey on K8s."""
 
 import logging
+import signal
 from typing import override
 
 import ops
@@ -17,7 +18,7 @@ from common.exceptions import (
     ValkeyServicesFailedToStartError,
     ValkeyWorkloadCommandError,
 )
-from core.base_workload import TLSPaths, WorkloadBase
+from core.base_workload import ProcessHandle, TLSPaths, WorkloadBase
 from literals import (
     ACL_FILE,
     CHARM,
@@ -27,6 +28,35 @@ from literals import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _K8sProcessHandle:
+    """ProcessHandle implementation backed by Pebble exec."""
+
+    def __init__(self, process: ops.pebble.ExecProcess):
+        self._process = process
+        self.stdout = process.stdout
+
+    def wait(self) -> tuple[int, str]:
+        try:
+            _, stderr = self._process.wait_output()
+            stderr_text = (
+                stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else (stderr or "")
+            )
+            return 0, stderr_text
+        except ops.pebble.ExecError as e:
+            stderr_text = (
+                e.stderr.decode("utf-8", "replace")
+                if isinstance(e.stderr, bytes)
+                else (e.stderr or "")
+            )
+            return e.exit_code, stderr_text
+
+    def kill(self) -> None:
+        try:
+            self._process.send_signal(signal.SIGKILL)
+        except ops.pebble.Error as e:
+            logger.warning("Failed to send SIGKILL to Pebble exec: %s", e)
 
 
 class ValkeyK8sWorkload(WorkloadBase):
@@ -142,6 +172,12 @@ class ValkeyK8sWorkload(WorkloadBase):
         except ops.pebble.ExecError as e:
             logger.error("Command failed with: %s, %s", e.exit_code, e.stdout)
             raise ValkeyWorkloadCommandError(e)
+
+    @override
+    def exec_stream(self, command: list[str]) -> ProcessHandle:
+        return _K8sProcessHandle(
+            self.container.exec(command=command, encoding=None, timeout=None)
+        )
 
     @override
     def stop(self) -> None:

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -4,8 +4,10 @@
 
 """Implementation of WorkloadBase for running Valkey on K8s."""
 
+import collections
 import logging
 import signal
+import threading
 from typing import override
 
 import ops
@@ -31,26 +33,42 @@ logger = logging.getLogger(__name__)
 
 
 class _K8sProcessHandle:
-    """ProcessHandle implementation backed by Pebble exec."""
+    """ProcessHandle implementation backed by Pebble exec.
+
+    stdout is streamed to the caller unbuffered. stderr is drained on a
+    daemon thread into a bounded buffer so a chatty child cannot fill the
+    pipe and block. wait() returns the exit code WITHOUT calling
+    wait_output() -- the latter would buffer the entire stdout (the whole
+    RDB) into the charm container's memory.
+    """
 
     def __init__(self, process: ops.pebble.ExecProcess):
         self._process = process
         self.stdout = process.stdout
+        self._stderr_buf: collections.deque[bytes] = collections.deque(maxlen=64)
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stderr_thread.start()
+
+    def _drain_stderr(self) -> None:
+        if self._process.stderr is None:
+            return
+        try:
+            for chunk in iter(lambda: self._process.stderr.read(4096), b""):
+                self._stderr_buf.append(chunk)
+        except Exception:
+            logger.exception("stderr drain thread failed")
 
     def wait(self) -> tuple[int, str]:
         try:
-            _, stderr = self._process.wait_output()
-            stderr_text = (
-                stderr.decode("utf-8", "replace") if isinstance(stderr, bytes) else (stderr or "")
-            )
-            return 0, stderr_text
+            self._process.wait()
+            rc = 0
         except ops.pebble.ExecError as e:
-            stderr_text = (
-                e.stderr.decode("utf-8", "replace")
-                if isinstance(e.stderr, bytes)
-                else (e.stderr or "")
-            )
-            return e.exit_code, stderr_text
+            rc = e.exit_code
+        except ops.pebble.ChangeError as e:
+            logger.error("Pebble exec did not complete: %s", e)
+            rc = -1
+        self._stderr_thread.join(timeout=5)
+        return rc, b"".join(self._stderr_buf).decode("utf-8", "replace")
 
     def kill(self) -> None:
         try:

--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -175,9 +175,7 @@ class ValkeyK8sWorkload(WorkloadBase):
 
     @override
     def exec_stream(self, command: list[str]) -> ProcessHandle:
-        return _K8sProcessHandle(
-            self.container.exec(command=command, encoding=None, timeout=None)
-        )
+        return _K8sProcessHandle(self.container.exec(command=command, encoding=None, timeout=None))
 
     @override
     def stop(self) -> None:

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -60,12 +60,19 @@ class _VmProcessHandle:
     def _drain_stderr(self) -> None:
         if self._proc.stderr is None:
             return
-        for chunk in iter(lambda: self._proc.stderr.read(4096), b""):
-            self._stderr_buf.append(chunk)
+        try:
+            for chunk in iter(lambda: self._proc.stderr.read(4096), b""):
+                self._stderr_buf.append(chunk)
+        except Exception:
+            logger.exception("stderr drain thread failed")
 
     def wait(self) -> tuple[int, str]:
         rc = self._proc.wait()
-        self._stderr_thread.join(timeout=5)
+        # The process has exited; closing stderr unblocks the drain thread's
+        # blocking read() so the join() below cannot hang.
+        if self._proc.stderr is not None:
+            self._proc.stderr.close()
+        self._stderr_thread.join()
         return rc, b"".join(self._stderr_buf).decode("utf-8", "replace")
 
     def kill(self) -> None:

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -46,7 +46,14 @@ logger = logging.getLogger(__name__)
 
 
 class _VmProcessHandle:
-    """ProcessHandle implementation backed by subprocess.Popen."""
+    """ProcessHandle backed by ``subprocess.Popen`` (VM substrate).
+
+    stdout is the Popen pipe, streamed to the caller unbuffered. stderr is
+    drained on a daemon thread so a chatty child cannot fill the pipe and
+    deadlock the upload. ``wait()`` returns the real process exit code and
+    reaps the child; ``kill()`` sends SIGKILL and waits briefly so the
+    process does not linger as a zombie.
+    """
 
     def __init__(self, proc: subprocess.Popen):
         self._proc = proc

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -50,7 +50,8 @@ class _VmProcessHandle:
 
     def __init__(self, proc: subprocess.Popen):
         self._proc = proc
-        assert proc.stdout is not None  # set via stdout=subprocess.PIPE
+        if proc.stdout is None:  # asserts compile away under -O
+            raise RuntimeError("subprocess.Popen must be created with stdout=PIPE")
         self.stdout = proc.stdout
         self._stderr_buf: list[bytes] = []
         self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -4,6 +4,7 @@
 
 """Implementation of WorkloadBase for running Valkey on VMs."""
 
+import collections
 import logging
 import os
 import platform
@@ -60,7 +61,9 @@ class _VmProcessHandle:
         if proc.stdout is None:  # asserts compile away under -O
             raise RuntimeError("subprocess.Popen must be created with stdout=PIPE")
         self.stdout = proc.stdout
-        self._stderr_buf: list[bytes] = []
+        # Bounded: a chatty child must not grow this without limit over a
+        # long-running stream. Only the tail is kept, matching the K8s handle.
+        self._stderr_buf: collections.deque[bytes] = collections.deque(maxlen=64)
         self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
         self._stderr_thread.start()
 

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -68,6 +68,12 @@ class _VmProcessHandle:
         self._stderr_thread.start()
 
     def _drain_stderr(self) -> None:
+        """Drain the child's stderr into the bounded tail buffer until EOF.
+
+        Runs on a daemon thread so a chatty child cannot fill the stderr
+        pipe and block the caller draining stdout. Read failures are logged
+        and terminate the thread rather than propagating to the caller.
+        """
         if self._proc.stderr is None:
             return
         try:
@@ -194,7 +200,7 @@ class ValkeyVmWorkload(WorkloadBase):
                 text=True,
                 capture_output=True,
                 timeout=10,
-                env={**os.environ, **env} if env else None,
+                env={**os.environ, **env} if env else os.environ,
             )
             return output.stdout, output.stderr
         except subprocess.CalledProcessError as e:

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -74,10 +74,11 @@ class _VmProcessHandle:
         pipe and block the caller draining stdout. Read failures are logged
         and terminate the thread rather than propagating to the caller.
         """
-        if self._proc.stderr is None:
+        stderr = self._proc.stderr
+        if stderr is None:
             return
         try:
-            for chunk in iter(lambda: self._proc.stderr.read(4096), b""):
+            for chunk in iter(lambda: stderr.read(4096), b""):
                 self._stderr_buf.append(chunk)
         except Exception:
             logger.exception("stderr drain thread failed")

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -5,6 +5,7 @@
 """Implementation of WorkloadBase for running Valkey on VMs."""
 
 import logging
+import os
 import platform
 import subprocess
 import threading
@@ -165,7 +166,9 @@ class ValkeyVmWorkload(WorkloadBase):
             ) from e
 
     @override
-    def exec(self, command: list[str]) -> tuple[str, str | None]:
+    def exec(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> tuple[str, str | None]:
         try:
             output = subprocess.run(
                 command,
@@ -173,6 +176,7 @@ class ValkeyVmWorkload(WorkloadBase):
                 text=True,
                 capture_output=True,
                 timeout=10,
+                env={**os.environ, **env} if env else None,
             )
             return output.stdout, output.stderr
         except subprocess.CalledProcessError as e:
@@ -183,13 +187,16 @@ class ValkeyVmWorkload(WorkloadBase):
             raise ValkeyWorkloadCommandError(e)
 
     @override
-    def exec_stream(self, command: list[str]) -> ProcessHandle:
+    def exec_stream(
+        self, command: list[str], env: dict[str, str] | None = None
+    ) -> ProcessHandle:
         return _VmProcessHandle(
             subprocess.Popen(
                 command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 bufsize=0,
+                env={**os.environ, **env} if env else None,
             )
         )
 

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -7,6 +7,7 @@
 import logging
 import platform
 import subprocess
+import threading
 import time
 from typing import override
 
@@ -26,7 +27,7 @@ from common.exceptions import (
     ValkeyServicesFailedToStartError,
     ValkeyWorkloadCommandError,
 )
-from core.base_workload import TLSPaths, WorkloadBase
+from core.base_workload import ProcessHandle, TLSPaths, WorkloadBase
 from literals import (
     SNAP_ACL_FILE,
     SNAP_COMMON_PATH,
@@ -41,6 +42,36 @@ from literals import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _VmProcessHandle:
+    """ProcessHandle implementation backed by subprocess.Popen."""
+
+    def __init__(self, proc: subprocess.Popen):
+        self._proc = proc
+        assert proc.stdout is not None  # set via stdout=subprocess.PIPE
+        self.stdout = proc.stdout
+        self._stderr_buf: list[bytes] = []
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stderr_thread.start()
+
+    def _drain_stderr(self) -> None:
+        if self._proc.stderr is None:
+            return
+        for chunk in iter(lambda: self._proc.stderr.read(4096), b""):
+            self._stderr_buf.append(chunk)
+
+    def wait(self) -> tuple[int, str]:
+        rc = self._proc.wait()
+        self._stderr_thread.join(timeout=5)
+        return rc, b"".join(self._stderr_buf).decode("utf-8", "replace")
+
+    def kill(self) -> None:
+        self._proc.kill()
+        try:
+            self._proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("Process did not exit within 10s of SIGKILL")
 
 
 class ValkeyVmWorkload(WorkloadBase):
@@ -150,6 +181,17 @@ class ValkeyVmWorkload(WorkloadBase):
         except subprocess.TimeoutExpired as e:
             logger.error("Command timed out: %s", str(e.stderr))
             raise ValkeyWorkloadCommandError(e)
+
+    @override
+    def exec_stream(self, command: list[str]) -> ProcessHandle:
+        return _VmProcessHandle(
+            subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+            )
+        )
 
     @override
     @retry(

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -205,9 +205,7 @@ class ValkeyVmWorkload(WorkloadBase):
             raise ValkeyWorkloadCommandError(e)
 
     @override
-    def exec_stream(
-        self, command: list[str], env: dict[str, str] | None = None
-    ) -> ProcessHandle:
+    def exec_stream(self, command: list[str], env: dict[str, str] | None = None) -> ProcessHandle:
         return _VmProcessHandle(
             subprocess.Popen(
                 command,

--- a/src/workload_vm.py
+++ b/src/workload_vm.py
@@ -218,7 +218,7 @@ class ValkeyVmWorkload(WorkloadBase):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 bufsize=0,
-                env={**os.environ, **env} if env else None,
+                env={**os.environ, **env} if env else os.environ,
             )
         )
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -60,6 +60,7 @@ def test_k8s_exec_stream_delegates_to_container_exec(mocker):
         command=["valkey-cli", "--rdb", "-"],
         encoding=None,
         timeout=None,
+        environment=None,
     )
     assert handle.stdout is fake_process.stdout
 
@@ -74,9 +75,26 @@ def test_build_command_prefix_no_tls(mocker):
     prefix = client.build_command_prefix(json_output=True)
     assert prefix[0] == "valkey-cli"
     assert "--user" in prefix and "op" in prefix
-    assert "--pass" in prefix and "pw" in prefix
     assert "--json" in prefix
     assert "--tls" not in prefix
+    # The password must never reach argv; it goes via REDISCLI_AUTH.
+    assert "--pass" not in prefix
+    assert "pw" not in prefix
+
+
+def test_exec_cli_command_passes_password_via_env(mocker):
+    from src.common.client import CliClient
+
+    workload = mocker.MagicMock()
+    workload.cli = "valkey-cli"
+    workload.exec.return_value = ("OK", None)
+    client = CliClient(username="op", password="sekret", tls=False, workload=workload)
+    client.exec_cli_command(["ping"], hostname="h", json_output=False)
+
+    _args, kwargs = workload.exec.call_args
+    assert kwargs["env"] == {"REDISCLI_AUTH": "sekret"}
+    sent_argv = workload.exec.call_args[0][0]
+    assert "--pass" not in sent_argv and "sekret" not in sent_argv
 
 
 def test_build_command_prefix_with_tls(mocker):

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -24,9 +24,7 @@ def test_vm_exec_stream_streams_stdout_and_collects_stderr():
     from src.workload_vm import ValkeyVmWorkload
 
     workload = ValkeyVmWorkload.__new__(ValkeyVmWorkload)
-    handle = workload.exec_stream(
-        ["sh", "-c", "printf 'hello-stream'; printf 'oops' 1>&2"]
-    )
+    handle = workload.exec_stream(["sh", "-c", "printf 'hello-stream'; printf 'oops' 1>&2"])
     body = handle.stdout.read()
     rc, stderr = handle.wait()
     assert body == b"hello-stream"
@@ -61,6 +59,40 @@ def test_k8s_exec_stream_delegates_to_container_exec(mocker):
         timeout=None,
     )
     assert handle.stdout is fake_process.stdout
+
+
+def test_build_command_prefix_no_tls(mocker):
+    from src.common.client import CliClient
+
+    workload = mocker.MagicMock()
+    workload.cli = "valkey-cli"
+    client = CliClient(username="op", password="pw", tls=False, workload=workload)
+    client.port = 6379
+    prefix = client.build_command_prefix(json_output=True)
+    assert prefix[0] == "valkey-cli"
+    assert "--user" in prefix and "op" in prefix
+    assert "--pass" in prefix and "pw" in prefix
+    assert "--json" in prefix
+    assert "--tls" not in prefix
+
+
+def test_build_command_prefix_with_tls(mocker):
+    from src.common.client import CliClient
+
+    workload = mocker.MagicMock()
+    workload.cli = "valkey-cli"
+    workload.tls_paths.client_cert.as_posix.return_value = "/c"
+    workload.tls_paths.client_key.as_posix.return_value = "/k"
+    workload.tls_paths.ca_certs_dir.as_posix.return_value = "/ca"
+    client = CliClient(username="op", password="pw", tls=True, workload=workload)
+    client.port = 6380
+    prefix = client.build_command_prefix(json_output=False, hostname="h")
+    assert "--tls" in prefix
+    assert "--cert" in prefix and "/c" in prefix
+    assert "--key" in prefix and "/k" in prefix
+    assert "--cacertdir" in prefix and "/ca" in prefix
+    assert "-h" in prefix and "h" in prefix
+    assert "--json" not in prefix
 
 
 def test_k8s_exec_stream_wait_returns_rc_and_stderr(mocker):

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -144,8 +144,7 @@ def test_build_command_prefix_with_tls(mocker):
 
 
 def test_k8s_exec_stream_wait_streams_without_buffering_stdout(mocker):
-    """wait() must call process.wait(), never wait_output() (which buffers
-    the whole RDB into the charm container's memory)."""
+    """wait() must call process.wait(), never the RDB-buffering wait_output()."""
     import io
 
     from ops.pebble import ExecError

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -42,3 +42,50 @@ def test_vm_exec_stream_kill_terminates():
     handle.kill()
     rc, _ = handle.wait()
     assert rc != 0
+
+
+def test_k8s_exec_stream_delegates_to_container_exec(mocker):
+    from src.workload_k8s import ValkeyK8sWorkload
+
+    container = mocker.MagicMock()
+    fake_process = mocker.MagicMock()
+    fake_process.stdout = b""
+    container.exec.return_value = fake_process
+
+    workload = ValkeyK8sWorkload(container=container)
+    handle = workload.exec_stream(["valkey-cli", "--rdb", "-"])
+
+    container.exec.assert_called_once_with(
+        command=["valkey-cli", "--rdb", "-"],
+        encoding=None,
+        timeout=None,
+    )
+    assert handle.stdout is fake_process.stdout
+
+
+def test_k8s_exec_stream_wait_returns_rc_and_stderr(mocker):
+    from ops.pebble import ExecError
+
+    from src.workload_k8s import ValkeyK8sWorkload
+
+    container = mocker.MagicMock()
+    fake_process = mocker.MagicMock()
+    # wait_output() on a successful binary process returns (stdout_bytes, stderr_bytes)
+    fake_process.wait_output.return_value = (b"", b"oops")
+    container.exec.return_value = fake_process
+
+    workload = ValkeyK8sWorkload(container=container)
+    handle = workload.exec_stream(["true"])
+    rc, stderr = handle.wait()
+
+    assert rc == 0
+    assert stderr == "oops"
+
+    # Failing exec
+    fake_process.wait_output.side_effect = ExecError(
+        command=["false"], exit_code=2, stdout=b"", stderr=b"boom"
+    )
+    handle = workload.exec_stream(["false"])
+    rc, stderr = handle.wait()
+    assert rc == 2
+    assert stderr == "boom"

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -43,11 +43,14 @@ def test_vm_exec_stream_kill_terminates():
 
 
 def test_k8s_exec_stream_delegates_to_container_exec(mocker):
+    import io
+
     from src.workload_k8s import ValkeyK8sWorkload
 
     container = mocker.MagicMock()
     fake_process = mocker.MagicMock()
-    fake_process.stdout = b""
+    fake_process.stdout = io.BytesIO(b"")
+    fake_process.stderr = io.BytesIO(b"")
     container.exec.return_value = fake_process
 
     workload = ValkeyK8sWorkload(container=container)
@@ -95,15 +98,20 @@ def test_build_command_prefix_with_tls(mocker):
     assert "--json" not in prefix
 
 
-def test_k8s_exec_stream_wait_returns_rc_and_stderr(mocker):
+def test_k8s_exec_stream_wait_streams_without_buffering_stdout(mocker):
+    """wait() must call process.wait(), never wait_output() (which buffers
+    the whole RDB into the charm container's memory)."""
+    import io
+
     from ops.pebble import ExecError
 
     from src.workload_k8s import ValkeyK8sWorkload
 
     container = mocker.MagicMock()
     fake_process = mocker.MagicMock()
-    # wait_output() on a successful binary process returns (stdout_bytes, stderr_bytes)
-    fake_process.wait_output.return_value = (b"", b"oops")
+    fake_process.stdout = io.BytesIO(b"")
+    fake_process.stderr = io.BytesIO(b"oops")
+    fake_process.wait.return_value = None
     container.exec.return_value = fake_process
 
     workload = ValkeyK8sWorkload(container=container)
@@ -112,11 +120,17 @@ def test_k8s_exec_stream_wait_returns_rc_and_stderr(mocker):
 
     assert rc == 0
     assert stderr == "oops"
+    fake_process.wait.assert_called_once()
+    fake_process.wait_output.assert_not_called()
 
-    # Failing exec
-    fake_process.wait_output.side_effect = ExecError(
-        command=["false"], exit_code=2, stdout=b"", stderr=b"boom"
+    # Failing exec: process.wait() raises ExecError carrying the exit code.
+    fake_process2 = mocker.MagicMock()
+    fake_process2.stdout = io.BytesIO(b"")
+    fake_process2.stderr = io.BytesIO(b"boom")
+    fake_process2.wait.side_effect = ExecError(
+        command=["false"], exit_code=2, stdout=b"", stderr=b""
     )
+    container.exec.return_value = fake_process2
     handle = workload.exec_stream(["false"])
     rc, stderr = handle.wait()
     assert rc == 2

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -65,6 +65,33 @@ def test_k8s_exec_stream_delegates_to_container_exec(mocker):
     assert handle.stdout is fake_process.stdout
 
 
+def test_k8s_process_handle_kill_distinguishes_pebble_errors(mocker, caplog):
+    """kill() logs an unreachable Pebble at ERROR but a no-op signal at DEBUG."""
+    import logging
+
+    import ops
+
+    from src.workload_k8s import _K8sProcessHandle
+
+    process = mocker.MagicMock()
+    process.stderr = None  # no stderr drain work
+    handle = _K8sProcessHandle(process)
+
+    # Pebble unreachable: the exec may still be running and unstoppable.
+    process.send_signal.side_effect = ops.pebble.ConnectionError("no socket")
+    with caplog.at_level(logging.DEBUG):
+        handle.kill()
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+    caplog.clear()
+    # Any other pebble error: most likely the exec already exited -- benign.
+    process.send_signal.side_effect = ops.pebble.Error("cannot send signal")
+    with caplog.at_level(logging.DEBUG):
+        handle.kill()
+    assert caplog.records
+    assert all(r.levelno == logging.DEBUG for r in caplog.records)
+
+
 def test_build_command_prefix_no_tls(mocker):
     from src.common.client import CliClient
 

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the workload streaming exec primitive."""
+
+
+def test_workload_base_declares_exec_stream():
+    import inspect
+
+    from src.core.base_workload import ProcessHandle, WorkloadBase
+
+    assert hasattr(WorkloadBase, "exec_stream")
+    annotations = (
+        ProcessHandle.__annotations__ if hasattr(ProcessHandle, "__annotations__") else {}
+    )
+    assert "stdout" in annotations
+    members = {name for name, _ in inspect.getmembers(ProcessHandle)}
+    assert "wait" in members
+    assert "kill" in members

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -18,3 +18,27 @@ def test_workload_base_declares_exec_stream():
     members = {name for name, _ in inspect.getmembers(ProcessHandle)}
     assert "wait" in members
     assert "kill" in members
+
+
+def test_vm_exec_stream_streams_stdout_and_collects_stderr():
+    from src.workload_vm import ValkeyVmWorkload
+
+    workload = ValkeyVmWorkload.__new__(ValkeyVmWorkload)
+    handle = workload.exec_stream(
+        ["sh", "-c", "printf 'hello-stream'; printf 'oops' 1>&2"]
+    )
+    body = handle.stdout.read()
+    rc, stderr = handle.wait()
+    assert body == b"hello-stream"
+    assert rc == 0
+    assert "oops" in stderr
+
+
+def test_vm_exec_stream_kill_terminates():
+    from src.workload_vm import ValkeyVmWorkload
+
+    workload = ValkeyVmWorkload.__new__(ValkeyVmWorkload)
+    handle = workload.exec_stream(["sh", "-c", "sleep 30"])
+    handle.kill()
+    rc, _ = handle.wait()
+    assert rc != 0

--- a/tests/unit/test_workload_exec_stream.py
+++ b/tests/unit/test_workload_exec_stream.py
@@ -4,12 +4,20 @@
 
 """Unit tests for the workload streaming exec primitive."""
 
+import inspect
+import io
+import logging
+
+import ops
+from ops.pebble import ExecError
+
+from src.common.client import CliClient
+from src.core.base_workload import ProcessHandle, WorkloadBase
+from src.workload_k8s import ValkeyK8sWorkload, _K8sProcessHandle
+from src.workload_vm import ValkeyVmWorkload
+
 
 def test_workload_base_declares_exec_stream():
-    import inspect
-
-    from src.core.base_workload import ProcessHandle, WorkloadBase
-
     assert hasattr(WorkloadBase, "exec_stream")
     annotations = (
         ProcessHandle.__annotations__ if hasattr(ProcessHandle, "__annotations__") else {}
@@ -21,8 +29,6 @@ def test_workload_base_declares_exec_stream():
 
 
 def test_vm_exec_stream_streams_stdout_and_collects_stderr():
-    from src.workload_vm import ValkeyVmWorkload
-
     workload = ValkeyVmWorkload.__new__(ValkeyVmWorkload)
     handle = workload.exec_stream(["sh", "-c", "printf 'hello-stream'; printf 'oops' 1>&2"])
     body = handle.stdout.read()
@@ -33,8 +39,6 @@ def test_vm_exec_stream_streams_stdout_and_collects_stderr():
 
 
 def test_vm_exec_stream_kill_terminates():
-    from src.workload_vm import ValkeyVmWorkload
-
     workload = ValkeyVmWorkload.__new__(ValkeyVmWorkload)
     handle = workload.exec_stream(["sh", "-c", "sleep 30"])
     handle.kill()
@@ -43,10 +47,6 @@ def test_vm_exec_stream_kill_terminates():
 
 
 def test_k8s_exec_stream_delegates_to_container_exec(mocker):
-    import io
-
-    from src.workload_k8s import ValkeyK8sWorkload
-
     container = mocker.MagicMock()
     fake_process = mocker.MagicMock()
     fake_process.stdout = io.BytesIO(b"")
@@ -67,12 +67,6 @@ def test_k8s_exec_stream_delegates_to_container_exec(mocker):
 
 def test_k8s_process_handle_kill_distinguishes_pebble_errors(mocker, caplog):
     """kill() logs an unreachable Pebble at ERROR but a no-op signal at DEBUG."""
-    import logging
-
-    import ops
-
-    from src.workload_k8s import _K8sProcessHandle
-
     process = mocker.MagicMock()
     process.stderr = None  # no stderr drain work
     handle = _K8sProcessHandle(process)
@@ -93,8 +87,6 @@ def test_k8s_process_handle_kill_distinguishes_pebble_errors(mocker, caplog):
 
 
 def test_build_command_prefix_no_tls(mocker):
-    from src.common.client import CliClient
-
     workload = mocker.MagicMock()
     workload.cli = "valkey-cli"
     client = CliClient(username="op", password="pw", tls=False, workload=workload)
@@ -104,14 +96,12 @@ def test_build_command_prefix_no_tls(mocker):
     assert "--user" in prefix and "op" in prefix
     assert "--json" in prefix
     assert "--tls" not in prefix
-    # The password must never reach argv; it goes via REDISCLI_AUTH.
+    # The password must never reach argv; it goes via VALKEYCLI_AUTH.
     assert "--pass" not in prefix
     assert "pw" not in prefix
 
 
 def test_exec_cli_command_passes_password_via_env(mocker):
-    from src.common.client import CliClient
-
     workload = mocker.MagicMock()
     workload.cli = "valkey-cli"
     workload.exec.return_value = ("OK", None)
@@ -119,14 +109,12 @@ def test_exec_cli_command_passes_password_via_env(mocker):
     client.exec_cli_command(["ping"], hostname="h", json_output=False)
 
     _args, kwargs = workload.exec.call_args
-    assert kwargs["env"] == {"REDISCLI_AUTH": "sekret"}
+    assert kwargs["env"] == {"VALKEYCLI_AUTH": "sekret"}
     sent_argv = workload.exec.call_args[0][0]
     assert "--pass" not in sent_argv and "sekret" not in sent_argv
 
 
 def test_build_command_prefix_with_tls(mocker):
-    from src.common.client import CliClient
-
     workload = mocker.MagicMock()
     workload.cli = "valkey-cli"
     workload.tls_paths.client_cert.as_posix.return_value = "/c"
@@ -145,12 +133,6 @@ def test_build_command_prefix_with_tls(mocker):
 
 def test_k8s_exec_stream_wait_streams_without_buffering_stdout(mocker):
     """wait() must call process.wait(), never the RDB-buffering wait_output()."""
-    import io
-
-    from ops.pebble import ExecError
-
-    from src.workload_k8s import ValkeyK8sWorkload
-
     container = mocker.MagicMock()
     fake_process = mocker.MagicMock()
     fake_process.stdout = io.BytesIO(b"")


### PR DESCRIPTION
## Summary

Adds a `ProcessHandle` protocol and `exec_stream(command)` method to `WorkloadBase`
for spawning long-running commands whose stdout streams to the caller as raw bytes,
plus VM and K8s implementations. Also extracts `CliClient.build_command_prefix(...)`
from the existing `exec_cli_command` to make the valkey-cli argv construction
reusable.

This is generic platform infrastructure — useful for any feature that needs to
pipe binary output from the workload to a downstream consumer (e.g. uploading
RDB snapshots, streaming logs, exporting backups). The first consumer will be
the S3 backup feature (separate PR).

## Why this is split out

`exec()` buffers stdout, applies a short timeout, and operates in text mode.
None of those are appropriate for streaming binary payloads. Rather than bolt
the new primitive into the backup PR, it lives here as a standalone improvement.