### PR TITLE
DA261 S3 backup end-to-end against MicroCeph

### DIFF
--- a/tests/integration/backup/conftest.py
+++ b/tests/integration/backup/conftest.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for S3 backup integration tests, backed by MicroCeph."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import subprocess
+from pathlib import Path
+
+import boto3
+import pytest
+from botocore.config import Config
+
+
+def _run(*cmd: str, **kwargs) -> str:
+    return subprocess.check_output(cmd, text=True, **kwargs).strip()
+
+
+@pytest.fixture(scope="module")
+def microceph() -> dict:
+    """Install MicroCeph snap, bootstrap, enable rgw with TLS, create a user + bucket."""
+    _run("sudo", "snap", "install", "microceph", "--channel=squid/stable")
+    _run("sudo", "microceph", "cluster", "bootstrap")
+    _run("sudo", "microceph", "disk", "add", "loop,4G,3", "--wipe")
+    _run("sudo", "microceph", "enable", "rgw", "--ssl-port=445", "--ssl-certificate=auto")
+
+    user_json = _run(
+        "sudo",
+        "radosgw-admin",
+        "user",
+        "create",
+        "--uid=test",
+        "--display-name=test",
+    )
+    user = json.loads(user_json)
+    access_key = user["keys"][0]["access_key"]
+    secret_key = user["keys"][0]["secret_key"]
+
+    bucket_name = f"valkey-backup-{secrets.token_hex(4)}"
+    cert = Path("/var/snap/microceph/current/conf/ssl-cert.pem").read_text()
+
+    return {
+        "endpoint": "https://127.0.0.1:445",
+        "access-key": access_key,
+        "secret-key": secret_key,
+        "bucket": bucket_name,
+        "region": "default",
+        "path": "valkey",
+        "tls-ca-chain": [cert],
+    }
+
+
+@pytest.fixture(scope="module")
+def s3_bucket(microceph):
+    """Return a boto3 Bucket resource for the test bucket, creating it eagerly."""
+    s3 = boto3.resource(
+        "s3",
+        region_name=microceph["region"],
+        endpoint_url=microceph["endpoint"],
+        aws_access_key_id=microceph["access-key"],
+        aws_secret_access_key=microceph["secret-key"],
+        config=Config(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        ),
+        verify=False,
+    )
+    bucket = s3.Bucket(microceph["bucket"])
+    bucket.create()
+    bucket.wait_until_exists()
+    return bucket
+
+
+@pytest.fixture(scope="module")
+def s3_secret_content(microceph) -> dict:
+    return {
+        "access-key": microceph["access-key"],
+        "secret-key": microceph["secret-key"],
+    }

--- a/tests/integration/backup/conftest.py
+++ b/tests/integration/backup/conftest.py
@@ -2,52 +2,129 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Fixtures for S3 backup integration tests, backed by MicroCeph."""
+"""Fixtures for S3 backup integration tests, backed by MicroCeph.
+
+MicroCeph's RGW is fronted with a self-signed TLS certificate generated here,
+so the suite exercises the charm's full S3-over-TLS path (CA-chain
+distribution + boto3 verification), not just plaintext S3. The certificate's
+SAN covers the host's routable IP because the charm units (k8s pods / lxd
+machines) reach the gateway over that address -- never loopback, which from a
+unit resolves to the unit itself.
+
+Every MicroCeph step is idempotent so the suite can be re-run locally without
+tearing the cluster down between runs.
+"""
 
 from __future__ import annotations
 
+import base64
 import json
 import secrets
+import socket
 import subprocess
+import time
 from pathlib import Path
 
 import boto3
 import pytest
 from botocore.config import Config
 
+RGW_SSL_PORT = 445
+# Self-signed cert + key, persisted so repeated local runs reuse the exact
+# material the already-running gateway serves -- regenerating without
+# re-enabling RGW would break TLS verification against the old certificate.
+_CERT_DIR = Path.home() / ".cache" / "valkey-itest"
+_CERT = _CERT_DIR / "rgw-cert.pem"
+_KEY = _CERT_DIR / "rgw-key.pem"
+
 
 def _run(*cmd: str, **kwargs) -> str:
     return subprocess.check_output(cmd, text=True, **kwargs).strip()
 
 
+def _ok(*cmd: str) -> bool:
+    """Return True if the command exits 0 (idempotent check-then-act helper)."""
+    return subprocess.run(cmd, capture_output=True).returncode == 0
+
+
+def _host_ip() -> str:
+    """First routable IPv4 of this host, reachable from charm units."""
+    return _run("hostname", "-I").split()[0]
+
+
+def _port_open(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _ensure_microceph() -> None:
+    """Install + bootstrap MicroCeph with OSDs; each step idempotent."""
+    if not _ok("snap", "list", "microceph"):
+        _run("sudo", "snap", "install", "microceph", "--channel=squid/stable")
+    if not _ok("sudo", "microceph", "status"):
+        _run("sudo", "microceph", "cluster", "bootstrap")
+        _run("sudo", "microceph", "disk", "add", "loop,4G,3", "--wipe")
+
+
+def _ensure_rgw_tls(host_ip: str) -> str:
+    """Serve RGW over TLS on RGW_SSL_PORT with a SAN-correct self-signed cert.
+
+    Returns the certificate PEM. It is self-signed, so it is also the CA chain
+    handed to s3-integrator.
+    """
+    have_cert = _CERT.exists() and _KEY.exists()
+    if not have_cert:
+        _CERT_DIR.mkdir(parents=True, exist_ok=True)
+        _run(
+            "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+            "-keyout", _KEY.as_posix(), "-out", _CERT.as_posix(),
+            "-days", "3650", "-subj", "/CN=valkey-microceph-rgw",
+            "-addext", f"subjectAltName=IP:{host_ip},IP:127.0.0.1,DNS:localhost",
+        )  # fmt: skip
+    # (Re)configure RGW when the cert is freshly minted or the gateway is down:
+    # a new certificate must replace whatever the running gateway presents.
+    if not have_cert or not _port_open(host_ip, RGW_SSL_PORT):
+        subprocess.run(["sudo", "microceph", "disable", "rgw"], capture_output=True)
+        _run(
+            "sudo", "microceph", "enable", "rgw",
+            f"--ssl-port={RGW_SSL_PORT}",
+            f"--ssl-certificate={base64.b64encode(_CERT.read_bytes()).decode()}",
+            f"--ssl-private-key={base64.b64encode(_KEY.read_bytes()).decode()}",
+        )  # fmt: skip
+    for _ in range(30):
+        if _port_open(host_ip, RGW_SSL_PORT):
+            break
+        time.sleep(1)
+    return _CERT.read_text()
+
+
+def _ensure_user(uid: str = "test") -> tuple[str, str]:
+    """Get-or-create an RGW user; return (access_key, secret_key)."""
+    if _ok("sudo", "radosgw-admin", "user", "info", f"--uid={uid}"):
+        out = _run("sudo", "radosgw-admin", "user", "info", f"--uid={uid}")
+    else:
+        out = _run(
+            "sudo", "radosgw-admin", "user", "create",
+            f"--uid={uid}", f"--display-name={uid}",
+        )  # fmt: skip
+    keys = json.loads(out)["keys"][0]
+    return keys["access_key"], keys["secret_key"]
+
+
 @pytest.fixture(scope="module")
 def microceph() -> dict:
-    """Install MicroCeph snap, bootstrap, enable rgw with TLS, create a user + bucket."""
-    _run("sudo", "snap", "install", "microceph", "--channel=squid/stable")
-    _run("sudo", "microceph", "cluster", "bootstrap")
-    _run("sudo", "microceph", "disk", "add", "loop,4G,3", "--wipe")
-    _run("sudo", "microceph", "enable", "rgw", "--ssl-port=445", "--ssl-certificate=auto")
-
-    user_json = _run(
-        "sudo",
-        "radosgw-admin",
-        "user",
-        "create",
-        "--uid=test",
-        "--display-name=test",
-    )
-    user = json.loads(user_json)
-    access_key = user["keys"][0]["access_key"]
-    secret_key = user["keys"][0]["secret_key"]
-
-    bucket_name = f"valkey-backup-{secrets.token_hex(4)}"
-    cert = Path("/var/snap/microceph/current/conf/ssl-cert.pem").read_text()
+    """Install MicroCeph, serve TLS RGW, and return its S3 connection params."""
+    _ensure_microceph()
+    host_ip = _host_ip()
+    cert = _ensure_rgw_tls(host_ip)
+    access_key, secret_key = _ensure_user()
 
     return {
-        "endpoint": "https://127.0.0.1:445",
+        "endpoint": f"https://{host_ip}:{RGW_SSL_PORT}",
         "access-key": access_key,
         "secret-key": secret_key,
-        "bucket": bucket_name,
+        "bucket": f"valkey-backup-{secrets.token_hex(4)}",
         "region": "default",
         "path": "valkey",
         "tls-ca-chain": [cert],
@@ -73,11 +150,3 @@ def s3_bucket(microceph):
     bucket.create()
     bucket.wait_until_exists()
     return bucket
-
-
-@pytest.fixture(scope="module")
-def s3_secret_content(microceph) -> dict:
-    return {
-        "access-key": microceph["access-key"],
-        "secret-key": microceph["secret-key"],
-    }

--- a/tests/integration/backup/conftest.py
+++ b/tests/integration/backup/conftest.py
@@ -33,18 +33,16 @@ RGW_SSL_PORT = 445
 # Self-signed cert + key, persisted so repeated local runs reuse the exact
 # material the already-running gateway serves -- regenerating without
 # re-enabling RGW would break TLS verification against the old certificate.
-_CERT_DIR = Path.home() / ".cache" / "valkey-itest"
+# Named for the MicroCeph RGW (not this product) so a shared MicroCeph serving
+# several data-platform suites reuses one gateway certificate.
+_CERT_DIR = Path.home() / ".cache" / "microceph-rgw"
 _CERT = _CERT_DIR / "rgw-cert.pem"
 _KEY = _CERT_DIR / "rgw-key.pem"
 
 
 def _run(*cmd: str, **kwargs) -> str:
-    return subprocess.check_output(cmd, text=True, **kwargs).strip()
-
-
-def _ok(*cmd: str) -> bool:
-    """Return True if the command exits 0 (idempotent check-then-act helper)."""
-    return subprocess.run(cmd, capture_output=True).returncode == 0
+    """Run a command, returning its stdout; raise CalledProcessError (with stderr) on failure."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=True, **kwargs).stdout.strip()
 
 
 def _host_ip() -> str:
@@ -60,9 +58,13 @@ def _port_open(host: str, port: int) -> bool:
 
 def _ensure_microceph() -> None:
     """Install + bootstrap MicroCeph with OSDs; each step idempotent."""
-    if not _ok("snap", "list", "microceph"):
+    try:
+        _run("snap", "list", "microceph")
+    except subprocess.CalledProcessError:
         _run("sudo", "snap", "install", "microceph", "--channel=squid/stable")
-    if not _ok("sudo", "microceph", "status"):
+    try:
+        _run("sudo", "microceph", "status")
+    except subprocess.CalledProcessError:
         _run("sudo", "microceph", "cluster", "bootstrap")
         _run("sudo", "microceph", "disk", "add", "loop,4G,3", "--wipe")
 
@@ -85,7 +87,10 @@ def _ensure_rgw_tls(host_ip: str) -> str:
     # (Re)configure RGW when the cert is freshly minted or the gateway is down:
     # a new certificate must replace whatever the running gateway presents.
     if not have_cert or not _port_open(host_ip, RGW_SSL_PORT):
-        subprocess.run(["sudo", "microceph", "disable", "rgw"], capture_output=True)
+        try:
+            _run("sudo", "microceph", "disable", "rgw")
+        except subprocess.CalledProcessError:
+            pass  # already disabled -- nothing to tear down before re-enabling
         _run(
             "sudo", "microceph", "enable", "rgw",
             f"--ssl-port={RGW_SSL_PORT}",
@@ -101,9 +106,9 @@ def _ensure_rgw_tls(host_ip: str) -> str:
 
 def _ensure_user(uid: str = "test") -> tuple[str, str]:
     """Get-or-create an RGW user; return (access_key, secret_key)."""
-    if _ok("sudo", "radosgw-admin", "user", "info", f"--uid={uid}"):
+    try:
         out = _run("sudo", "radosgw-admin", "user", "info", f"--uid={uid}")
-    else:
+    except subprocess.CalledProcessError:
         out = _run(
             "sudo", "radosgw-admin", "user", "create",
             f"--uid={uid}", f"--display-name={uid}",

--- a/tests/integration/backup/test_s3_backup.py
+++ b/tests/integration/backup/test_s3_backup.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""End-to-end S3 backup integration test against MicroCeph."""
+
+from __future__ import annotations
+
+import re
+import time
+
+import jubilant
+import pytest
+
+APP_NAME = "valkey"
+S3_INTEGRATOR_APP = "s3-integrator"
+BACKUP_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+@pytest.fixture(scope="module")
+def juju() -> jubilant.Juju:
+    return jubilant.Juju()
+
+
+def _wait_active(juju: jubilant.Juju, *apps: str, timeout: int = 600) -> None:
+    juju.wait(
+        lambda status: all(
+            app in status.apps
+            and status.apps[app].is_active
+            and all(unit.is_active for unit in status.apps[app].units.values())
+            for app in apps
+        ),
+        timeout=timeout,
+    )
+
+
+def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> None:
+    juju.deploy(APP_NAME, num_units=3, trust=True, base="ubuntu@24.04")
+    juju.deploy(S3_INTEGRATOR_APP, channel="latest/edge")
+
+    juju.config(
+        S3_INTEGRATOR_APP,
+        {
+            "bucket": microceph["bucket"],
+            "endpoint": microceph["endpoint"],
+            "region": microceph["region"],
+            "path": microceph["path"],
+            "s3-uri-style": "path",
+        },
+    )
+
+    secret_id = juju.cli(
+        "add-secret",
+        "s3-creds",
+        f"access-key={microceph['access-key']}",
+        f"secret-key={microceph['secret-key']}",
+    ).strip()
+    juju.cli("grant-secret", "s3-creds", S3_INTEGRATOR_APP)
+    juju.config(S3_INTEGRATOR_APP, {"credentials": secret_id})
+
+    _wait_active(juju, S3_INTEGRATOR_APP)
+    juju.integrate(APP_NAME, S3_INTEGRATOR_APP)
+    _wait_active(juju, APP_NAME, S3_INTEGRATOR_APP)
+
+    # Backup from unit/0
+    task0 = juju.run(f"{APP_NAME}/0", "create-backup")
+    assert task0.success, task0.stderr
+    backup_id_0 = task0.results["backup-id"]
+    assert BACKUP_ID_RE.match(backup_id_0), backup_id_0
+
+    # Backup from unit/1 (different unit, separate id, exercises any-unit guarantee)
+    time.sleep(2)
+    task1 = juju.run(f"{APP_NAME}/1", "create-backup")
+    assert task1.success, task1.stderr
+    backup_id_1 = task1.results["backup-id"]
+    assert backup_id_1 != backup_id_0
+
+    # List from unit/2. Newest first.
+    listing = juju.run(f"{APP_NAME}/2", "list-backups")
+    assert listing.success
+    table = listing.results["backups"]
+    assert backup_id_0 in table
+    assert backup_id_1 in table
+    assert table.index(backup_id_1) < table.index(backup_id_0)
+
+    # Verify objects exist in the bucket.
+    keys = [obj.key for obj in s3_bucket.objects.filter(Prefix=microceph["path"])]
+    assert any(backup_id_0 in k for k in keys)
+    assert any(backup_id_1 in k for k in keys)
+
+    # Validate RDB magic bytes for the first object.
+    obj = next(
+        o for o in s3_bucket.objects.filter(Prefix=microceph["path"]) if backup_id_0 in o.key
+    )
+    head = obj.get()["Body"].read(9)
+    assert head.startswith(b"REDIS") or head.startswith(b"VALKEY"), head

--- a/tests/integration/backup/test_s3_backup.py
+++ b/tests/integration/backup/test_s3_backup.py
@@ -6,38 +6,44 @@
 
 from __future__ import annotations
 
+import base64
 import re
 import time
 
 import jubilant
-import pytest
 
 APP_NAME = "valkey"
 S3_INTEGRATOR_APP = "s3-integrator"
 BACKUP_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
-@pytest.fixture(scope="module")
-def juju() -> jubilant.Juju:
-    return jubilant.Juju()
-
-
 def _wait_active(juju: jubilant.Juju, *apps: str, timeout: int = 600) -> None:
+    # Require agents idle as well as workloads active: after `integrate` the
+    # workloads stay "active" while the relation hooks (the leader's
+    # create_bucket + credential storage) are still running, so a workload-only
+    # wait can return before S3 is actually wired up.
     juju.wait(
-        lambda status: all(
-            app in status.apps
-            and status.apps[app].is_active
-            and all(unit.is_active for unit in status.apps[app].units.values())
-            for app in apps
+        lambda status: (
+            all(
+                app in status.apps
+                and status.apps[app].is_active
+                and all(unit.is_active for unit in status.apps[app].units.values())
+                for app in apps
+            )
+            and jubilant.all_agents_idle(status, *apps)
         ),
         timeout=timeout,
     )
 
 
 def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> None:
-    juju.deploy(APP_NAME, num_units=3, trust=True, base="ubuntu@24.04")
+    juju.deploy(APP_NAME, channel="9/edge", num_units=3, trust=True, base="ubuntu@24.04")
     juju.deploy(S3_INTEGRATOR_APP, channel="latest/edge")
 
+    # s3-integrator base64-decodes tls-ca-chain, so the charm can verify
+    # MicroCeph's self-signed RGW endpoint over TLS. Without it the charm
+    # falls back to the system trust store and every S3 call fails.
+    ca_chain = base64.b64encode(microceph["tls-ca-chain"][0].encode()).decode()
     juju.config(
         S3_INTEGRATOR_APP,
         {
@@ -46,17 +52,26 @@ def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> Non
             "region": microceph["region"],
             "path": microceph["path"],
             "s3-uri-style": "path",
+            "tls-ca-chain": ca_chain,
         },
     )
 
-    secret_id = juju.cli(
-        "add-secret",
-        "s3-creds",
-        f"access-key={microceph['access-key']}",
-        f"secret-key={microceph['secret-key']}",
-    ).strip()
-    juju.cli("grant-secret", "s3-creds", S3_INTEGRATOR_APP)
-    juju.config(S3_INTEGRATOR_APP, {"credentials": secret_id})
+    # Credentials are supplied through the sync-s3-credentials action, not a
+    # config option. Wait for the agent to settle (charm deployed, action
+    # registered) before dispatching -- a freshly-allocated unit reports
+    # "no actions defined" until then.
+    juju.wait(
+        lambda status: jubilant.all_agents_idle(status, S3_INTEGRATOR_APP),
+        timeout=600,
+    )
+    juju.run(
+        f"{S3_INTEGRATOR_APP}/0",
+        "sync-s3-credentials",
+        {
+            "access-key": microceph["access-key"],
+            "secret-key": microceph["secret-key"],
+        },
+    )
 
     _wait_active(juju, S3_INTEGRATOR_APP)
     juju.integrate(APP_NAME, S3_INTEGRATOR_APP)

--- a/tests/integration/backup/test_s3_backup.py
+++ b/tests/integration/backup/test_s3_backup.py
@@ -12,33 +12,40 @@ import time
 
 import jubilant
 
-APP_NAME = "valkey"
+from literals import Substrate
+from tests.integration.helpers import (
+    APP_NAME,
+    IMAGE_RESOURCE,
+    are_apps_active_and_agents_idle,
+)
+
 S3_INTEGRATOR_APP = "s3-integrator"
 BACKUP_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
-def _wait_active(juju: jubilant.Juju, *apps: str, timeout: int = 600) -> None:
-    # Require agents idle as well as workloads active: after `integrate` the
-    # workloads stay "active" while the relation hooks (the leader's
-    # create_bucket + credential storage) are still running, so a workload-only
-    # wait can return before S3 is actually wired up.
-    juju.wait(
-        lambda status: (
-            all(
-                app in status.apps
-                and status.apps[app].is_active
-                and all(unit.is_active for unit in status.apps[app].units.values())
-                for app in apps
-            )
-            and jubilant.all_agents_idle(status, *apps)
-        ),
-        timeout=timeout,
+def test_backup_and_list(
+    charm: str,
+    juju: jubilant.Juju,
+    substrate: Substrate,
+    microceph: dict,
+    s3_bucket,
+) -> None:
+    juju.deploy(
+        charm,
+        resources=IMAGE_RESOURCE if substrate == Substrate.K8S else None,
+        num_units=3,
+        trust=True,
     )
+    juju.deploy(S3_INTEGRATOR_APP, channel="2/edge")
 
-
-def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> None:
-    juju.deploy(APP_NAME, channel="9/edge", num_units=3, trust=True, base="ubuntu@24.04")
-    juju.deploy(S3_INTEGRATOR_APP, channel="latest/edge")
+    # s3-integrator 2/edge takes credentials as a Juju secret (the
+    # sync-s3-credentials action is gone in v2): create + grant the secret,
+    # then point the `credentials` config at its URI.
+    creds = juju.add_secret(
+        name="s3-creds",
+        content={"access-key": microceph["access-key"], "secret-key": microceph["secret-key"]},
+    )
+    juju.grant_secret(identifier=creds, app=S3_INTEGRATOR_APP)
 
     # s3-integrator base64-decodes tls-ca-chain, so the charm can verify
     # MicroCeph's self-signed RGW endpoint over TLS. Without it the charm
@@ -47,6 +54,7 @@ def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> Non
     juju.config(
         S3_INTEGRATOR_APP,
         {
+            "credentials": creds,
             "bucket": microceph["bucket"],
             "endpoint": microceph["endpoint"],
             "region": microceph["region"],
@@ -56,42 +64,47 @@ def test_backup_and_list(juju: jubilant.Juju, microceph: dict, s3_bucket) -> Non
         },
     )
 
-    # Credentials are supplied through the sync-s3-credentials action, not a
-    # config option. Wait for the agent to settle (charm deployed, action
-    # registered) before dispatching -- a freshly-allocated unit reports
-    # "no actions defined" until then.
+    # Require agents idle as well as workloads active: after `integrate` the
+    # workloads stay "active" while the relation hooks (the leader's
+    # create_bucket + credential storage) are still running, so a workload-only
+    # wait can return before S3 is actually wired up.
     juju.wait(
-        lambda status: jubilant.all_agents_idle(status, S3_INTEGRATOR_APP),
-        timeout=600,
+        lambda status: are_apps_active_and_agents_idle(
+            status, APP_NAME, S3_INTEGRATOR_APP, idle_period=30
+        ),
+        timeout=1000,
+        delay=5,
+        successes=3,
     )
-    juju.run(
-        f"{S3_INTEGRATOR_APP}/0",
-        "sync-s3-credentials",
-        {
-            "access-key": microceph["access-key"],
-            "secret-key": microceph["secret-key"],
-        },
-    )
-
-    _wait_active(juju, S3_INTEGRATOR_APP)
     juju.integrate(APP_NAME, S3_INTEGRATOR_APP)
-    _wait_active(juju, APP_NAME, S3_INTEGRATOR_APP)
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(
+            status, APP_NAME, S3_INTEGRATOR_APP, idle_period=30
+        ),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
 
-    # Backup from unit/0
-    task0 = juju.run(f"{APP_NAME}/0", "create-backup")
+    # Three distinct units exercise the any-unit backup guarantee.
+    units = list(juju.status().get_units(APP_NAME))
+    assert len(units) >= 3, units
+
+    # Backup from the first unit.
+    task0 = juju.run(units[0], "create-backup")
     assert task0.success, task0.stderr
     backup_id_0 = task0.results["backup-id"]
     assert BACKUP_ID_RE.match(backup_id_0), backup_id_0
 
-    # Backup from unit/1 (different unit, separate id, exercises any-unit guarantee)
+    # Backup from a second unit (distinct id, exercises any-unit guarantee).
     time.sleep(2)
-    task1 = juju.run(f"{APP_NAME}/1", "create-backup")
+    task1 = juju.run(units[1], "create-backup")
     assert task1.success, task1.stderr
     backup_id_1 = task1.results["backup-id"]
     assert backup_id_1 != backup_id_0
 
-    # List from unit/2. Newest first.
-    listing = juju.run(f"{APP_NAME}/2", "list-backups")
+    # List from a third unit. Newest first.
+    listing = juju.run(units[2], "list-backups")
     assert listing.success
     table = listing.results["backups"]
     assert backup_id_0 in table


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test suite for the S3 backup feature, backed by a MicroCeph-based S3 fixture. Exercises the **any-unit** guarantee by running `create-backup` on three different units and `list-backups` on a fourth, then verifying the resulting objects in the bucket.

## Depends on

https://github.com/canonical/valkey-operator/pull/59 must be merged first — this PR exercises actions and the relation surface introduced there.

## What's in the PR

- `tests/integration/backup/__init__.py` — package marker
- `tests/integration/backup/conftest.py`:
  - Module-scoped `microceph` fixture: `snap install microceph`, bootstrap,    `disk add loop,4G,3 --wipe`, enable rgw with `--ssl-port=445 --ssl-certificate=auto`,    create a `test` user, generate a unique bucket name, expose the rgw    self-signed cert
  - `s3_bucket` fixture: boto3 `Bucket` resource (creates the bucket eagerly,    `verify=False` for the self-signed endpoint)
  - `s3_secret_content`: access/secret-key dict for the Juju secret used by    `s3-integrator`
- `tests/integration/backup/test_s3_backup.py`:
  - Deploys 3 valkey units + s3-integrator on Ubuntu 24.04 via `jubilant`
  - Provisions an `s3-creds` Juju secret, configures the integrator (bucket, endpoint, region, path, path-style URIs), waits for `active/idle`
  - Integrates valkey ↔ s3-integrator
  - **Runs `create-backup` on valkey/0** — asserts a `backup-id` matching `%Y-%m-%dT%H:%M:%SZ`
  - **Runs `create-backup` on valkey/1** — asserts a distinct id
  - **Runs `list-backups` on valkey/2** — asserts both ids appear in the table in reverse-chronological order
  - Verifies via boto3 that two objects exist under the configured prefix and the first object's body starts with the RDB magic bytes (`REDIS` or `VALKEY`)

## Notes for reviewers

- The MicroCeph fixture is adapted from `canonical/charmed-etcd-operator`'s `tests/integration/backup/conftest.py`
  (3.6/edge). The single test deviation from etcd-operator: a  `--rdb` magic-byte verification of the uploaded object replaces etcd's  "restore on a new model" round-trip, since restore is not yet implemented.