### PR TITLE
test(ha): harden flaky tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -8,7 +8,7 @@ backends:
     allocate: |
       hash=$(python3 -c "import hashlib; print(hashlib.sha256('$SPREAD_PASSWORD'.encode()).hexdigest()[:6])")
       VM_NAME="${VM_NAME:-${SPREAD_SYSTEM//./-}-${hash}}"
-      DISK="${DISK:-20}"
+      DISK="${DISK:-25}"
       CPU="${CPU:-4}"
       MEM="${MEM:-8}"
 

--- a/tests/integration/ha/helpers/deploy_chaos_mesh.sh
+++ b/tests/integration/ha/helpers/deploy_chaos_mesh.sh
@@ -18,7 +18,14 @@ deploy_chaos_mesh() {
     fi
 
     echo "installing chaos-mesh"
-    microk8s.helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}"
+    # --wait blocks until the controller-manager Deployment and the chaos-daemon
+    # DaemonSet report Ready, so the admission webhook (mnetworkchaos.kb.io) is
+    # serving and the daemon can program rules before any test applies a
+    # NetworkChaos. Without it the test races chaos-mesh startup: the webhook
+    # refuses connections and the loss rule is enforced late (packets leak).
+    microk8s.helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}" --wait --timeout 5m0s
+    # Brief extra settle for the webhook's serving cert/endpoints to propagate
+    # after the pod is Ready; the apply itself is also retried (see helpers.py).
     sleep 10
 }
 

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -92,21 +92,28 @@ def k8s_cut_network_from_unit_without_ip_change(model_name: str, machine_name: s
             temp_file.write(str.encode(chaos_network_loss))
             temp_file.flush()
 
-        # Apply the generated manifest, chaosmesh would then make the pod inaccessible
+        # Apply the generated manifest, chaosmesh would then make the pod inaccessible.
+        # The chaos-mesh admission webhook (mnetworkchaos.kb.io) can take a while to
+        # start serving after the controller-manager is installed; until it does the
+        # apply fails with a transient "connection refused" calling the webhook. Retry
+        # for a bounded window so the webhook has time to come up.
         env = os.environ
         env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
-        try:
-            command_result = subprocess.check_output(
-                " ".join(["microk8s", "kubectl", "apply", "-f", temp_file.name]),
-                shell=True,
-                env=env,
-                stderr=subprocess.STDOUT,
-            )
-        except subprocess.CalledProcessError as err:
-            logger.error(
-                f"Failed to apply network isolation: [{err.returncode}] {err.stderr=}, {err.stdout=}"
-            )
-            raise
+        command_result = None
+        for attempt in Retrying(stop=stop_after_delay(120), wait=wait_fixed(5), reraise=True):
+            with attempt:
+                try:
+                    command_result = subprocess.check_output(
+                        " ".join(["microk8s", "kubectl", "apply", "-f", temp_file.name]),
+                        shell=True,
+                        env=env,
+                        stderr=subprocess.STDOUT,
+                    )
+                except subprocess.CalledProcessError as err:
+                    logger.error(
+                        f"Failed to apply network isolation: [{err.returncode}] {err.stderr=}, {err.stdout=}"
+                    )
+                    raise
         logger.info("Result of isolating unit from cluster is '%s'", command_result)
 
 

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -144,8 +144,11 @@ def test_network_cut_primary(  # noqa: C901
     logger.info("Verifying new primary election...")
 
     new_primary_ip = None
-    # failover should happen after 30s
-    for attempt in Retrying(stop=stop_after_attempt(4), wait=wait_fixed(10), reraise=True):
+    # Sentinel only marks the old primary down after `down-after-milliseconds` (30s,
+    # see src/managers/config.py) and then needs time to reach quorum and promote a
+    # replica, so a new primary cannot appear before ~30s. Wait well past that (but
+    # under the 180s `failover-timeout`) to absorb CI scheduling jitter.
+    for attempt in Retrying(stop=stop_after_attempt(15), wait=wait_fixed(10), reraise=True):
         with attempt:
             try:
                 # we exclude the old primary ip because on k8s the unit is reachable by ip


### PR DESCRIPTION
test_network_cut_primary flakes in CI for two independent reasons:

- VM: the new-primary election wait was ~30s (stop_after_attempt(4) x wait_fixed(10)), but Sentinel's down-after-milliseconds is 30s (src/managers/config.py), so the final attempt landed exactly when failover begins -- before any replica is promoted. Widen the window to ~140s, still under the 180s failover-timeout. The loop breaks as soon as a new primary appears, so the happy path is unaffected.

- K8s: applying the Chaos Mesh NetworkChaos manifest races the mnetworkchaos.kb.io admission webhook coming up and fails with "connection refused". Retry the idempotent apply for a bounded window so the webhook has time to start serving.



- [ ] Have you updated relevant documentation?
