### PR TITLE
fix(ha): don't wedge the app when scale-down lock can't be acquired

### DIFF
--- a/src/common/locks.py
+++ b/src/common/locks.py
@@ -8,8 +8,6 @@ import time
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol, override
 
-from tenacity import Retrying, stop_after_attempt, wait_fixed
-
 from common.client import ValkeyClient
 from core.cluster_state import ClusterState
 from literals import CharmUsers
@@ -246,38 +244,47 @@ class ScaleDownLock(Lockable):
             logger.debug("Last unit in the cluster scaling down. Lock will be skipped.")
             return True
 
-        number_of_retries = min(timeout // 5 if timeout else 1, 1)
+        # Poll the lock: a contended SET NX returns falsy WITHOUT raising, so we
+        # must re-attempt on a fixed interval until it is acquired or the timeout
+        # elapses. With no timeout we make a single attempt and let the caller
+        # decide how to wait (e.g. defer the hook so juju re-runs it later).
+        number_of_retries = max(timeout // 5, 1) if timeout else 1
 
-        for attempt in Retrying(
-            wait=wait_fixed(5),
-            stop=stop_after_attempt(number_of_retries),
-            retry_error_callback=lambda _: False,
-            after=lambda retry_state: logger.info(
-                "%s failed to acquire %s lock on attempt %d. Retrying in 5 seconds.",
-                self.charm.state.unit_server.unit_name,
-                self.name,
-                retry_state.attempt_number,
-            ),
-        ):
-            with attempt:
-                # update the primary ip in case a failover happens when we are waiting to acquire the lock
-                primary_ip = self.charm.sentinel_manager.get_primary_ip()
-                if self.client.set(
-                    hostname=primary_ip,
-                    key=self.lock_key,
-                    value=self.charm.state.unit_server.unit_name,
-                    additional_args=[
-                        "NX",
-                        "PX",
-                        str(
-                            5 * 60 * 1000
-                        ),  # Set the lock with a TTL of 5 minutes to prevent deadlocks
-                    ],
-                ):
-                    logger.debug(
-                        "%s acquired %s lock.", self.charm.state.unit_server.unit_name, self.name
-                    )
-                    return True
+        # ValkeyClient is a stateless command builder (a fresh valkey-cli per call),
+        # so build it once rather than on every property access in the loop.
+        client = self.client
+
+        for attempt in range(number_of_retries):
+            if attempt > 0:
+                # we slept since the last attempt, so a failover may have happened:
+                # re-resolve the primary, using the resilient lookup that rides out
+                # the transient sentinel failures common during teardown.
+                primary_ip = self.charm.sentinel_manager.get_primary_ip_for_scale_down()
+            if client.set(
+                hostname=primary_ip,
+                key=self.lock_key,
+                value=self.charm.state.unit_server.unit_name,
+                additional_args=[
+                    "NX",
+                    "PX",
+                    str(
+                        5 * 60 * 1000
+                    ),  # Set the lock with a TTL of 5 minutes to prevent deadlocks
+                ],
+            ):
+                logger.debug(
+                    "%s acquired %s lock.", self.charm.state.unit_server.unit_name, self.name
+                )
+                return True
+
+            if attempt < number_of_retries - 1:
+                logger.info(
+                    "%s failed to acquire %s lock on attempt %d. Retrying in 5 seconds.",
+                    self.charm.state.unit_server.unit_name,
+                    self.name,
+                    attempt + 1,
+                )
+                time.sleep(5)
 
         return False
 

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -27,6 +27,7 @@ from literals import (
     INTERNAL_USERS_PASSWORD_CONFIG,
     INTERNAL_USERS_SECRET_LABEL_SUFFIX,
     PEER_RELATION,
+    SCALE_DOWN_LOCK_TIMEOUT,
     SENTINEL_PORT,
     SENTINEL_TLS_PORT,
     TLS_PORT,
@@ -528,7 +529,7 @@ class BaseEvents(ops.Object):
             component=self.charm.cluster_manager.name,
         )
 
-    def _on_storage_detaching(self, event: ops.StorageDetachingEvent) -> None:
+    def _on_storage_detaching(self, event: ops.StorageDetachingEvent) -> None:  # noqa: C901
         """Handle removal of the data storage mount, e.g. when removing a unit."""
         # get scale down lock
         scale_down_lock = ScaleDownLock(self.charm)
@@ -547,8 +548,44 @@ class BaseEvents(ops.Object):
             self._set_state_for_going_away()
             return
 
-        # blocks until the lock is acquired
-        if not scale_down_lock.request_lock(primary_ip=primary_ip):
+        # waits (in-process) up to the timeout for the lock
+        try:
+            lock_acquired = scale_down_lock.request_lock(
+                timeout=SCALE_DOWN_LOCK_TIMEOUT, primary_ip=primary_ip
+            )
+        except (ValkeyCannotGetPrimaryIPError, ValkeyWorkloadCommandError) as e:
+            # The primary/sentinels became unreachable while we were acquiring the lock.
+            if self.charm.app.planned_units() == 0:
+                # Expected during full-app removal (every unit detaches at once and the
+                # peers that would coordinate are going away too). There is nothing left
+                # to coordinate with, so go away rather than wedge the unit in error.
+                logger.warning(
+                    "%s: primary/sentinels unreachable while acquiring the scale-down lock "
+                    "during full-app removal; going away. (%s)",
+                    self.charm.state.unit_server.unit_name,
+                    e,
+                )
+                self._set_state_for_going_away()
+                return
+            # Partial scale-down: surface the error so juju retries the hook once the
+            # cluster settles, instead of tearing the unit down without coordinating
+            # failover and the data save.
+            logger.error(e)
+            raise
+
+        if not lock_acquired:
+            # On full-app removal every unit detaches at once and the peers that
+            # would hand off the lock are themselves going away, so it may never
+            # free. Don't wedge this unit in error: its agent gets torn down
+            # before juju can retry the hook, which would leave the whole
+            # application stuck mid-removal. Just go away.
+            if self.charm.app.planned_units() == 0:
+                logger.info(
+                    "%s: whole application is being removed; going away without the scale-down lock.",
+                    self.charm.state.unit_server.unit_name,
+                )
+                self._set_state_for_going_away()
+                return
             raise RequestingLockTimedOutError("Failed to acquire scale down lock within timeout")
 
         self.charm.state.statuses.delete(

--- a/src/literals.py
+++ b/src/literals.py
@@ -51,6 +51,11 @@ TLS_CLIENT_PRIVATE_KEY_CONFIG = "tls-client-private-key"
 
 DATA_STORAGE = "data"
 
+# How long a unit waits in-process to acquire the scale-down lock before either
+# deferring the storage-detaching hook (so juju re-runs it) or, on full-app
+# removal, going away. Kept well under juju's hook timeout.
+SCALE_DOWN_LOCK_TIMEOUT = 30
+
 
 # As per the valkey users spec
 # https://docs.google.com/document/d/1EImKKHK3wLY73-D1M2ItpHe88NHeB-Iq2M3lz7AQB7E

--- a/tests/unit/test_locks.py
+++ b/tests/unit/test_locks.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for the cluster operation locks."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from common.locks import ScaleDownLock
+
+
+def _make_charm(unit_name="valkey/0", primary_ip="10.0.1.0", active_sentinels=None):
+    """Build a stub charm exposing only what ScaleDownLock touches."""
+    charm = MagicMock()
+    charm.app.name = "valkey"
+    charm.state.unit_server.unit_name = unit_name
+    charm.sentinel_manager.get_primary_ip.return_value = primary_ip
+    charm.sentinel_manager.get_primary_ip_for_scale_down.return_value = primary_ip
+    charm.sentinel_manager.get_active_sentinel_ips.return_value = (
+        active_sentinels if active_sentinels is not None else ["10.0.1.0", "10.0.1.1"]
+    )
+    return charm
+
+
+def test_request_lock_retries_until_lock_frees():
+    """request_lock keeps polling SET NX until a contended lock frees, then acquires it."""
+    lock = ScaleDownLock(_make_charm())
+
+    with (
+        patch.object(ScaleDownLock, "client", new_callable=PropertyMock) as mock_client_prop,
+        patch("common.locks.time.sleep") as mock_sleep,
+    ):
+        client = mock_client_prop.return_value
+        client.get.return_value = None  # nobody currently holds the lock key
+        client.set.side_effect = [None, "OK"]  # peer holds it, then it frees
+
+        acquired = lock.request_lock(timeout=10)
+
+    assert acquired is True
+    assert client.set.call_count == 2
+    mock_sleep.assert_called_once()  # waited once between the two attempts
+
+
+def test_request_lock_uses_resilient_primary_lookup_on_retry():
+    """On retry the lock re-resolves the primary via the resilient scale-down lookup.
+
+    get_primary_ip_for_scale_down rides out the transient sentinel failures common during
+    teardown; the bare get_primary_ip does not. Attempt 0 reuses the caller-provided
+    primary_ip (no lookup), and only the retry re-resolves it.
+    """
+    charm = _make_charm()
+    lock = ScaleDownLock(charm)
+
+    with (
+        patch.object(ScaleDownLock, "client", new_callable=PropertyMock) as mock_client_prop,
+        patch("common.locks.time.sleep"),
+    ):
+        client = mock_client_prop.return_value
+        client.get.return_value = None  # nobody currently holds the lock key
+        client.set.side_effect = [None, "OK"]  # contended once, then frees
+
+        assert lock.request_lock(timeout=10, primary_ip="10.0.1.0") is True
+
+    charm.sentinel_manager.get_primary_ip_for_scale_down.assert_called_once()
+    charm.sentinel_manager.get_primary_ip.assert_not_called()

--- a/tests/unit/test_scaledown.py
+++ b/tests/unit/test_scaledown.py
@@ -9,7 +9,7 @@ from ops import testing
 
 from charm import ValkeyCharm
 from common.exceptions import ValkeyCannotGetPrimaryIPError, ValkeyWorkloadCommandError
-from literals import CONTAINER, PEER_RELATION
+from literals import CONTAINER, PEER_RELATION, ScaleDownState
 from statuses import ScaleDownStatuses
 from tests.unit.helpers import status_is
 
@@ -62,6 +62,179 @@ def test_other_unit_has_lock(cloud_spec):
         with pytest.raises(testing.errors.UncaughtCharmError) as exc_info:
             ctx.run(ctx.on.storage_detaching(data_storage), state_in)
         assert "RequestingLockTimedOutError" in str(exc_info.value)
+
+
+def test_full_app_removal_does_not_wedge_when_lock_unavailable(cloud_spec):
+    """On full-app removal a unit that can't get the scale-down lock goes away, not error.
+
+    Removing the whole application fires storage-detaching on every unit at once; the
+    losers of the lock race must not raise (which would wedge them in error state with a
+    lost agent and block the application from ever being removed).
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = get_3_unit_peer_relation()
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    data_storage = testing.Storage(name="data")
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation},
+        leader=True,
+        containers={container},
+        storages={data_storage},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch(
+            "managers.sentinel.SentinelManager.get_primary_ip_for_scale_down",
+            return_value="10.0.1.1",
+        ),
+        patch("common.locks.ScaleDownLock.request_lock", return_value=False),
+        patch("workload_k8s.ValkeyK8sWorkload.stop") as mock_stop,
+        patch("core.models.ValkeyCluster.update"),
+        patch("ops.model.Application.planned_units", return_value=0),
+    ):
+        # Must complete without raising RequestingLockTimedOutError.
+        state_out = ctx.run(ctx.on.storage_detaching(data_storage), state_in)
+
+    mock_stop.assert_not_called()
+    out_relation = state_out.get_relations(PEER_RELATION)[0]
+    assert out_relation.local_unit_data["scale-down-state"] == ScaleDownState.GOING_AWAY.value
+
+
+def test_storage_detaching_goes_away_if_primary_lost_acquiring_lock(cloud_spec):
+    """On full-app removal, a primary loss while acquiring the lock goes away, not error.
+
+    request_lock re-reads the primary IP from sentinels; during full-app removal that can
+    raise ValkeyCannotGetPrimaryIPError, which must be tolerated (go away) rather than
+    wedging the unit in error. (Partial scale-down re-raises instead; see
+    test_partial_scale_down_does_not_go_away_if_primary_lost.)
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = get_3_unit_peer_relation()
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    data_storage = testing.Storage(name="data")
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation},
+        leader=True,
+        containers={container},
+        storages={data_storage},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch(
+            "managers.sentinel.SentinelManager.get_primary_ip_for_scale_down",
+            return_value="10.0.1.1",
+        ),
+        patch(
+            "common.locks.ScaleDownLock.request_lock",
+            side_effect=ValkeyCannotGetPrimaryIPError("primary gone"),
+        ),
+        patch("workload_k8s.ValkeyK8sWorkload.stop") as mock_stop,
+        patch("core.models.ValkeyCluster.update"),
+        patch("ops.model.Application.planned_units", return_value=0),
+    ):
+        # Must complete without raising.
+        state_out = ctx.run(ctx.on.storage_detaching(data_storage), state_in)
+
+    mock_stop.assert_not_called()
+    out_relation = state_out.get_relations(PEER_RELATION)[0]
+    assert out_relation.local_unit_data["scale-down-state"] == ScaleDownState.GOING_AWAY.value
+
+
+def test_partial_scale_down_does_not_go_away_if_primary_lost(cloud_spec):
+    """A primary loss during a PARTIAL scale-down must raise, not silently go away.
+
+    Only full-app removal (planned_units() == 0) may go away without the lock. During a
+    single-unit scale-down the unit must surface the error so juju retries the hook, rather
+    than tearing itself down without coordinating failover and the data save.
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = get_3_unit_peer_relation()
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    data_storage = testing.Storage(name="data")
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation},
+        leader=True,
+        containers={container},
+        storages={data_storage},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch(
+            "managers.sentinel.SentinelManager.get_primary_ip_for_scale_down",
+            return_value="10.0.1.1",
+        ),
+        patch(
+            "common.locks.ScaleDownLock.request_lock",
+            side_effect=ValkeyCannotGetPrimaryIPError("primary gone"),
+        ),
+        patch("workload_k8s.ValkeyK8sWorkload.stop") as mock_stop,
+        patch("core.models.ValkeyCluster.update"),
+        patch("ops.model.Application.planned_units", return_value=2),
+    ):
+        with pytest.raises(testing.errors.UncaughtCharmError):
+            ctx.run(ctx.on.storage_detaching(data_storage), state_in)
+
+    mock_stop.assert_not_called()
+
+
+def test_full_app_removal_goes_away_if_sentinel_query_fails(cloud_spec):
+    """On full-app removal a sentinel/workload error while acquiring the lock must not wedge.
+
+    request_lock can raise ValkeyWorkloadCommandError (e.g. the sentinel query in
+    get_active_sentinel_ips fails during teardown), not just ValkeyCannotGetPrimaryIPError.
+    On full-app removal that must be tolerated by going away rather than parking the unit in
+    error and blocking the application's removal.
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = get_3_unit_peer_relation()
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    data_storage = testing.Storage(name="data")
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation},
+        leader=True,
+        containers={container},
+        storages={data_storage},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch(
+            "managers.sentinel.SentinelManager.get_primary_ip_for_scale_down",
+            return_value="10.0.1.1",
+        ),
+        patch(
+            "common.locks.ScaleDownLock.request_lock",
+            side_effect=ValkeyWorkloadCommandError("sentinel query failed"),
+        ),
+        patch("workload_k8s.ValkeyK8sWorkload.stop") as mock_stop,
+        patch("core.models.ValkeyCluster.update"),
+        patch("ops.model.Application.planned_units", return_value=0),
+    ):
+        # Must complete without raising.
+        state_out = ctx.run(ctx.on.storage_detaching(data_storage), state_in)
+
+    mock_stop.assert_not_called()
+    out_relation = state_out.get_relations(PEER_RELATION)[0]
+    assert out_relation.local_unit_data["scale-down-state"] == ScaleDownState.GOING_AWAY.value
 
 
 def test_non_primary(cloud_spec):


### PR DESCRIPTION
Removing the whole application fires storage-detaching on every unit at once. Each unit races for a single scale-down lock; the losers raised RequestingLockTimedOutError, which failed the hook and parked the unit in error state. Its agent is then torn down before juju can retry the hook, so the unit stays wedged and the application can never finish removing — `juju.wait(APP not in status)` times out (seen in k8s/test_scaling.py:: test_scale_down_remove_application).

- ScaleDownLock.request_lock now genuinely retries under contention. The retry count was `min(timeout // 5, 1)` (always 1) and a contended SET NX returns falsy WITHOUT raising, so tenacity never re-polled. Replace it with an explicit poll loop using `max(...)` so the timeout is honored. On retry it re-resolves the primary with the resilient get_primary_ip_for_scale_down() (which rides out transient sentinel failures during teardown) and builds the ValkeyClient once.

- _on_storage_detaching no longer raises when the lock is unavailable during full-app removal (planned_units() == 0): it goes away gracefully instead of wedging, logging at warning with the unit name. A partial single-unit scale-down still raises so juju retries the hook.

- While acquiring the lock, ValkeyCannotGetPrimaryIPError and ValkeyWorkloadCommandError (e.g. from get_active_sentinel_ips) are tolerated the same way: go away on full-app removal, otherwise re-raise so juju retries — rather than silently skipping failover and the dataset save on a partial scale-down.

Covered by unit tests in tests/unit/test_locks.py and tests/unit/test_scaledown.py.



- [ ] Have you updated relevant documentation?
