### PR TITLE
 Cleanup: align repo metadata, CI, and contributor docs with the renamed repo

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -3,7 +3,7 @@ name: Automatic doc checks
 
 on:
   push:
-    branches: [ main, */edge ]
+    branches: [ main, "*/edge" ]
   pull_request:
     paths:
       - 'docs/**'   # Only run on changes to the docs directory

--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -3,7 +3,7 @@ name: Automatic doc checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, */edge ]
   pull_request:
     paths:
       - 'docs/**'   # Only run on changes to the docs directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
       - "docs/**"
   schedule:
     - cron: "53 0 * * *" # Daily at 00:53 UTC
-  # Triggered on push to branch "dpe" by .github/workflows/release.yaml
+  # Triggered on push to branch "*/edge" by .github/workflows/release.yaml
   workflow_call:
     outputs:
       artifact-prefix:

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - */edge
     paths:
     - 'docs/**'   # Only run on changes to the docs directory
   pull_request:

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - main
-    - */edge
+    - "*/edge"
     paths:
     - 'docs/**'   # Only run on changes to the docs directory
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __pycache__
 coverage.xml
 .coverage
 .zed
+*.md~
+.full-review/
+.claude/
+docs/superpowers/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,48 +2,37 @@
 
 To make contributions to this charm, you'll need a working [development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/#set-things-up).
 
-### Testing
+## Pull requests
 
-We use `tox` for linting and testing. Run `tox -e lint` to perform code checking.
+- The default branch is `9/edge`. All changes land via pull requests, which are squash-merged with
+  conventional-commit subjects (`type(scope): summary`, e.g. `fix(tls): ...`, `test(ha): ...`).
+- You must have signed the [Canonical Contributor Licence Agreement](https://ubuntu.com/legal/contributors);
+  a CLA check runs on every pull request.
+- **Merging to `9/edge` releases**: every push to `9/edge` (except docs-only changes) runs the full
+  CI suite and then publishes the charm to Charmhub track `9`, channel `edge`, tagging the commit
+  `rev<N>`.
 
-To execute unit tests,run `tox -e unit`:
+## Testing
+
+We use `tox` for linting and testing:
 
 ```shell
-======================================================================================================================== test session starts =========================================================================================================================
-platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /home/rene/repos/charmed-valkey-operator/.tox/unit/bin/python
-cachedir: .tox/unit/.pytest_cache
-rootdir: /home/rene/repos/charmed-valkey-operator
-configfile: pyproject.toml
-plugins: mock-3.15.1, asyncio-1.3.0
-asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
-collected 4 items                                                                                                                                                                                                                                                    
-
-tests/unit/test_charm.py::test_pebble_ready_leader_unit PASSED
-tests/unit/test_charm.py::test_pebble_ready_non_leader_unit PASSED
-tests/unit/test_charm.py::test_update_status_leader_unit PASSED
-tests/unit/test_charm.py::test_update_status_non_leader_unit PASSED
-
-========================================================================================================================= 4 passed in 0.99s ==========================================================================================================================
-unit: commands[1]> poetry run coverage report
-Name                        Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
-src/charm.py                   34      1      6      1    95%   65
-src/core/base_workload.py      11      3      0      0    73%   16, 21, 30
-src/core/cluster_state.py      39     11      6      0    62%   49-52, 74, 87-101
-src/core/models.py             53      9      6      2    81%   51-54, 64, 92, 97, 115-117, 122
-src/events/base_events.py      16      2      4      0    80%   30-31
-src/literals.py                 6      0      0      0   100%
-src/managers/cluster.py        23      0      6      0   100%
-src/managers/config.py         36      0      4      0   100%
-src/statuses.py                 6      0      0      0   100%
-src/workload.py                32      4      2      1    85%   24, 70-73
------------------------------------------------------------------------
-TOTAL                         256     30     34      4    86%
-unit: commands[2]> poetry run coverage xml
-Wrote XML report to coverage.xml
-  unit: OK (5.05=setup[0.04]+cmd[1.50,2.38,0.57,0.57] seconds)
-  congratulations :) (5.11 seconds)
+tox run -e lint      # ruff check + ruff format --check + codespell + shellcheck
+tox run -e static    # pyright static type checks
+tox run -e format    # auto-fix style; also refreshes poetry.lock
+tox run -e unit      # unit tests (pytest + ops Scenario) with coverage
 ```
+
+Integration tests need a bootstrapped Juju controller (microk8s or lxd), a built charm in the
+repository root, and the built requirer charm (`charmcraft pack` inside
+`tests/integration/clients/requirer-charm/`):
+
+```shell
+tox run -e integration -- tests/integration/test_charm.py --substrate k8s   # or vm
+```
+
+Locally, the integration env creates a Juju model named `testing`; remove it
+(`juju destroy-model testing`) before re-running.
 
 ## Build the charm
 
@@ -56,21 +45,12 @@ You can also use `charmcraftcache` if desired.
 Make sure you have prepared an environment for deploying the charm code, e.g. a `microk8s` cloud + controller bootstrapped
 in Juju. For details, see [development setup](https://documentation.ubuntu.com/juju/3.6/howto/manage-your-juju-deployment/set-up-your-juju-deployment-local-testing-and-development/#set-things-up).
 
-In our case, we want to deploy `valkey` to a model `test` on a Kubernetes cloud. Use the `upstream-source` from `metadata.yaml`:
+Deploy with `--trust` (mandatory) and, on Kubernetes, the image resource using the
+`upstream-source` value from `metadata.yaml`:
+
 ```shell
-$ juju deploy ./valkey_ubuntu@24.04-amd64.charm -n 3 --resource valkey-image=ghcr.io/canonical/charmed-valkey:9.0.1-26.04_edge --trust
-
-$ juju status
-Model    Controller      Cloud/Region        Version  SLA          Timestamp
-testing  k8s-controller  microk8s/localhost  3.6.12   unsupported  08:39:26Z
-
-App     Version  Status   Scale  Charm   Channel  Rev  Address        Exposed  Message
-valkey           blocked      3  valkey             4  10.152.183.51  no       Scaling Valkey is not implemented yet
-
-Unit       Workload  Agent  Address      Ports  Message
-valkey/0*  active    idle   10.1.127.21         
-valkey/1   blocked   idle   10.1.127.20         Scaling Valkey is not implemented yet
-valkey/2   blocked   idle   10.1.127.22         Scaling Valkey is not implemented yet
+juju deploy ./valkey_ubuntu@24.04-amd64.charm -n 3 \
+  --resource valkey-image=<upstream-source from metadata.yaml> --trust
 ```
 
 If you deploy `valkey` on a VM cloud, you don't need to specify the image resource.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,11 +12,11 @@ description: |
   for caching and other realtime workloads. This charmed operator deploys 
   and operates Valkey in Kubernetes and VM environments.
 docs: https://canonical-charmed-valkey.readthedocs-hosted.com/latest/
-source: https://github.com/canonical/charmed-valkey-operator
-issues: https://github.com/canonical/charmed-valkey-operator/issues
+source: https://github.com/canonical/valkey-operator
+issues: https://github.com/canonical/valkey-operator/issues
 website:
   - https://charmhub.io/valkey
-  - https://github.com/canonical/charmed-valkey-operator
+  - https://github.com/canonical/valkey-operator
   - https://matrix.to/#/%23charmhub-data-platform%3Aubuntu.com
 
 containers:


### PR DESCRIPTION
Repository-hygiene pass on top of `9/edge` (after #57). No charm source (`src/`) or
test-logic changes.

### CI: trigger doc/markdown checks on `*/edge`
Releases happen on per-track edge branches (`9/edge`, future `10/edge`, …), but two
workflows only listed `main`. Add the `*/edge` glob alongside `main`, matching the
convention #57 already applied to `cla-check.yml` and `check-removed-urls.yml`.
- `automatic-doc-checks.yml`: push branches `[ main ]` → `[ main, */edge ]`
- `markdown-style-checks.yml`: add `*/edge` to push branches
- `ci.yaml`: correct the stale `# Triggered on push to branch "dpe"` comment → `"*/edge"`

### Metadata: point at the renamed repo
- `metadata.yaml`: `source`, `issues`, and `website` now reference
  `canonical/valkey-operator` (was `charmed-valkey-operator`).

### Docs: refresh `CONTRIBUTING.md`
- Remove a pasted unit-test + coverage transcript and a stale `juju status` dump
  (hardcoded local path, outdated revisions).
- Add a Pull requests / release section: default branch `9/edge`, squash-merge with
  conventional-commit subjects, CLA requirement, and the `9/edge` → Charmhub `9/edge`
  (`rev<N>`) release flow.
- Correct the `tox` commands, document `tox run -e static` (pyright), and add
  integration-test prerequisites.

### .gitignore
- Ignore editor backups (`*.md~`), review artifacts (`.full-review/`), and transient
  tooling state (`.claude/`, `docs/superpowers/`).