### PR TITLE
[DPE-10363] bugfix: set correct directory ownership when attaching a storage volume

### DIFF
--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -89,6 +89,8 @@ class BaseEvents(ops.Object):
                 )
             except ValkeyWorkloadCommandError as e:
                 logger.error("Error when ensuring storage ownership: %s", e)
+                event.defer()
+                return
 
         # fix the permissions of the directory if re-attaching existing storage
         self.charm.workload.exec(

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -93,9 +93,14 @@ class BaseEvents(ops.Object):
                 return
 
         # fix the permissions of the directory if re-attaching existing storage
-        self.charm.workload.exec(
-            ["chmod", "-R", "750", self.charm.workload.working_dir.as_posix()]
-        )
+        try:
+            self.charm.workload.exec(
+                ["chmod", "-R", "750", self.charm.workload.working_dir.as_posix()]
+            )
+        except ValkeyWorkloadCommandError as e:
+            logger.error("Error when setting storage permissions: %s", e)
+            event.defer()
+            return
 
     def _on_install(self, event: ops.InstallEvent) -> None:
         """Handle install event."""

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -78,14 +78,17 @@ class BaseEvents(ops.Object):
         if self.charm.state.substrate == Substrate.K8S:
             # some K8s clouds create a lost+found folder (owned by root) when attaching a volume
             # we need to ensure the path is accessible for the charm
-            self.charm.workload.exec(
-                [
-                    "chown",
-                    "-R",
-                    f"{self.charm.workload.user}:{self.charm.workload.user}",
-                    self.charm.workload.working_dir.as_posix(),
-                ]
-            )
+            try:
+                self.charm.workload.exec(
+                    [
+                        "chown",
+                        "-R",
+                        f"{self.charm.workload.user}:{self.charm.workload.user}",
+                        self.charm.workload.working_dir.as_posix(),
+                    ]
+                )
+            except ValkeyWorkloadCommandError as e:
+                logger.error("Error when ensuring storage ownership: %s", e)
 
         # fix the permissions of the directory if re-attaching existing storage
         self.charm.workload.exec(

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -76,7 +76,16 @@ class BaseEvents(ops.Object):
     def _on_storage_attached(self, event: ops.StorageAttachedEvent) -> None:
         """Handle storage attachment."""
         if self.charm.state.substrate == Substrate.K8S:
-            return
+            # some K8s clouds create a lost+found folder (owned by root) when attaching a volume
+            # we need to ensure the path is accessible for the charm
+            self.charm.workload.exec(
+                [
+                    "chown",
+                    "-R",
+                    f"{self.charm.workload.user}:{self.charm.workload.user}",
+                    self.charm.workload.working_dir.as_posix(),
+                ]
+            )
 
         # fix the permissions of the directory if re-attaching existing storage
         self.charm.workload.exec(


### PR DESCRIPTION
This PR fixes a bug related to deploying on Canonical K8s.

**Issue:**
When a storage volume is attached, some K8s clouds (such as Canonical K8s) create a `lost+found` folder (owned by root) on the mount point. This also sets the ownership of the storage path to `root` and makes the directory not accessible for writing files by the charm workload (which uses the `_daemon_` user).

This issue can be seen in this integration test: https://github.com/canonical/data-integrator/actions/runs/27890725877/job/82591369371?pr=280

Another evidence of this case can be found [here](https://github.com/canonical/postgresql-k8s-operator/issues/1009).

**Solution:**
When the storage-attached hook is run, the charm should ensure its storage volumes have the correct permissions and ownership.

**Testing:**
The issue was reproduced locally and the fix verified locally as well. Currently integration tests for Canonical K8s are not yet available.