### PR TITLE
chore: update metric exporter

### DIFF
--- a/src/workload_k8s.py
+++ b/src/workload_k8s.py
@@ -155,7 +155,7 @@ class ValkeyK8sWorkload(WorkloadBase):
                 self.metric_service: {
                     "override": "replace",
                     "summary": "Valkey metric exporter",
-                    "command": "bin/redis_exporter",
+                    "command": "bin/prometheus-redis-exporter",
                     "user": self.user,
                     "group": self.user,
                     "startup": "enabled",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -71,7 +71,7 @@ def test_start_primary(cloud_spec):
             SERVICE_METRIC_EXPORTER: {
                 "override": "replace",
                 "summary": "Valkey metric exporter",
-                "command": "bin/redis_exporter",
+                "command": "bin/prometheus-redis-exporter",
                 "user": CHARM_USER,
                 "group": CHARM_USER,
                 "startup": "enabled",


### PR DESCRIPTION
After the metric exporter in use has been changed in https://github.com/canonical/charmed-valkey-rock/pull/44, we need to adjust service creation in pebble for the charm.