### PR TITLE
[DPE-10363] Move integration tests from MicroK8s to Canonical K8s

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -105,6 +105,33 @@ jobs:
       - name: Disk usage
         timeout-minutes: 5
         run: df --human-readable
+      - name: Purge Docker
+        # GitHub-hosted Azure runners ship Docker pre-installed and active.
+        # Canonical K8s requires "A system with no previous installations
+        # of containerd/docker as this may cause conflicts"
+        # (see https://documentation.ubuntu.com/canonical-kubernetes
+        # /release-1.32/snap/tutorial/getting-started/).
+        # Completely purging Docker requires also
+        # deleting the Docker-specific `iptables-nft` rulesets
+        # created on installation.
+        timeout-minutes: 5
+        run: |
+          sudo apt-get remove --purge -y docker-ce docker-ce-cli containerd.io docker.io containerd 2>/dev/null || true
+          sudo nft flush ruleset
+          sudo ip link delete docker0 2>/dev/null || true
+      - name: Remove podman CNI bridge config
+        # Ubuntu 24.04 runners ship podman with a CNI bridge config
+        # (/etc/cni/net.d/87-podman-bridge.conflist) that sorts
+        # lexicographically before Cilium's config (05-cilium.conflist).
+        # When that file is present, containerd picks the podman bridge
+        # as the active CNI before Cilium is ready, bypassing the
+        # node.kubernetes.io/network-unavailable taint and scheduling
+        # pods onto the 10.88.0.0/16 bridge instead of the Cilium pod
+        # CIDR. Removing the file ensures Cilium is the only CNI plugin
+        # from the start.
+        timeout-minutes: 1
+        run: |
+          sudo rm -f /etc/cni/net.d/87-podman-bridge.conflist
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v5

--- a/concierge-k8s.yaml
+++ b/concierge-k8s.yaml
@@ -2,13 +2,12 @@ juju:
   model-defaults:
     logging-config: <root>=INFO; unit=DEBUG
 providers:
-  microk8s:
+  k8s:
     enable: true
     bootstrap: true
-    addons:
-      - dns
-      - hostpath-storage
-      - metallb:10.64.140.43-10.64.140.49
+    channel: 1.32-classic/stable
+    bootstrap-constraints:
+      root-disk: 5G
 host:
   snaps:
     jhack:

--- a/spread.yaml
+++ b/spread.yaml
@@ -95,7 +95,6 @@ backends:
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
       DOCKERHUB_MIRROR: "$(HOST: echo $DOCKERHUB_MIRROR)"
-      CONCIERGE_MICROK8S_CHANNEL: 1.34-strict/stable
     systems:
       - ubuntu-24.04:
           username: runner
@@ -118,30 +117,6 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && [[ $SPREAD_SUITE == *"k8s"* ]]
-  then
-    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
-    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
-
-    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
-
-    # Wait for microk8s to populate iptables
-    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
-    until [[ -n $(iptables --list | grep -i "microk8s") ]]
-    do
-      echo "MicroK8s has not yet configured iptables."
-      sleep 10
-    done
-
-    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
-    microk8s stop
-    microk8s start
-  fi
-
   # Install charmcraft & pipx (on lxd-vm backend)
   if [[ $SPREAD_SUITE == *"vm"* ]]
   then
@@ -151,6 +126,17 @@ prepare: |
   if [[ $SPREAD_SUITE == *"k8s"* ]]
   then
     concierge prepare --trace -c concierge-k8s.yaml
+  
+    # k8s status --wait-ready returns as soon as 1 node is ready
+    # (see https://github.com/canonical/k8s-snap/issues/1789)
+    # but Cilium, CoreDNS, and storage may still be initialising
+    for res in deployment/cilium-operator deployment/coredns deployment/metrics-server daemonset/cilium daemonset/ck-storage-rawfile-csi-node statefulset/ck-storage-rawfile-csi-controller; do
+        if k8s kubectl -n kube-system get "$res" >/dev/null 2>&1; then
+            k8s kubectl -n kube-system rollout status "$res" --timeout=5m
+        else
+            echo "Skipping rollout status for missing $res"
+        fi
+        done
   fi
 
   pipx install tox poetry

--- a/tests/integration/ha/helpers/deploy_chaos_mesh.sh
+++ b/tests/integration/ha/helpers/deploy_chaos_mesh.sh
@@ -12,9 +12,9 @@ if [ -z "${chaos_mesh_ns}" ]; then
 fi
 
 deploy_chaos_mesh() {
-    if [ "$(microk8s.helm repo list | grep -c 'chaos-mesh')" != "1" ]; then
-        echo "adding chaos-mesh microk8s.helm repo"
-        microk8s.helm repo add chaos-mesh https://charts.chaos-mesh.org
+    if [ "$(sudo k8s helm repo list | grep -c 'chaos-mesh')" != "1" ]; then
+        echo "adding chaos-mesh helm repo"
+        sudo k8s helm repo add chaos-mesh https://charts.chaos-mesh.org
     fi
 
     echo "installing chaos-mesh"
@@ -23,7 +23,7 @@ deploy_chaos_mesh() {
     # serving and the daemon can program rules before any test applies a
     # NetworkChaos. Without it the test races chaos-mesh startup: the webhook
     # refuses connections and the loss rule is enforced late (packets leak).
-    microk8s.helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/var/snap/microk8s/common/run/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}" --wait --timeout 5m0s
+    sudo k8s helm install chaos-mesh chaos-mesh/chaos-mesh --namespace="${chaos_mesh_ns}" --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock --set dashboard.create=false --version "${chaos_mesh_version}" --set clusterScoped=false --set controllerManager.targetNamespace="${chaos_mesh_ns}" --wait --timeout 5m0s
     # Brief extra settle for the webhook's serving cert/endpoints to propagate
     # after the pod is Ready; the apply itself is also retried (see helpers.py).
     sleep 10

--- a/tests/integration/ha/helpers/destroy_chaos_mesh.sh
+++ b/tests/integration/ha/helpers/destroy_chaos_mesh.sh
@@ -43,9 +43,9 @@ destroy_chaos_mesh() {
         timeout 30 kubectl delete crd "$(kubectl get crd | grep 'chaos-mesh.org' | awk '{print $1}')" || :
     fi
 
-    if [ -n "${chaos_mesh_ns}" ] && [ "$(microk8s.helm repo list --namespace "${chaos_mesh_ns}" | grep -c 'chaos-mesh')" = "1" ]; then
-        echo "uninstalling chaos-mesh microk8s.helm repo"
-        microk8s.helm uninstall chaos-mesh --namespace "${chaos_mesh_ns}" || :
+    if [ -n "${chaos_mesh_ns}" ] && [ "$(sudo k8s helm repo list --namespace "${chaos_mesh_ns}" | grep -c 'chaos-mesh')" = "1" ]; then
+        echo "uninstalling chaos-mesh helm repo"
+        sudo k8s helm uninstall chaos-mesh --namespace "${chaos_mesh_ns}" || :
     fi
 }
 

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -104,7 +104,7 @@ def k8s_cut_network_from_unit_without_ip_change(model_name: str, machine_name: s
             with attempt:
                 try:
                     command_result = subprocess.check_output(
-                        " ".join(["microk8s", "kubectl", "apply", "-f", temp_file.name]),
+                        " ".join(["sudo", "k8s", "kubectl", "apply", "-f", temp_file.name]),
                         shell=True,
                         env=env,
                         stderr=subprocess.STDOUT,
@@ -165,7 +165,7 @@ def restore_network_to_unit(
         env = os.environ
         env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")
         subprocess.check_output(
-            f"microk8s kubectl -n {model_name} delete networkchaos network-loss-primary",
+            f"sudo k8s kubectl -n {model_name} delete networkchaos network-loss-primary",
             shell=True,
             env=env,
         )

--- a/tests/integration/ha/test_scaling.py
+++ b/tests/integration/ha/test_scaling.py
@@ -44,11 +44,18 @@ def test_build_and_deploy(
     if existing_app(juju):
         return
 
+    # ensure enough storage is available for the dataset we are going to seed
+    if substrate == Substrate.K8S:
+        storage = {"data": "kubernetes,5G"}
+    else:
+        storage = None
+
     juju.deploy(
         charm,
         resources=IMAGE_RESOURCE if substrate == Substrate.K8S else None,
         num_units=1,
         trust=True,
+        storage=storage,
     )
     juju.deploy(glide_runner_charm, app=GLIDE_RUNNER_NAME)
     juju.wait(

--- a/tests/integration/ha/test_storage_reuse.py
+++ b/tests/integration/ha/test_storage_reuse.py
@@ -44,7 +44,8 @@ def test_build_and_deploy(
         juju.cli("create-storage-pool", "valkey-storage", "lxd")
         storage = {"data": "valkey-storage,2G"}
     else:
-        storage = None
+        # `kubernetes` is the default storage provider for the Canonical K8s cloud
+        storage = {"data": "kubernetes,5G"}
 
     juju.deploy(
         charm,


### PR DESCRIPTION
The goal of this PR is to replace MicroK8s with Canonical K8s as Kubernetes platform for integration tests.

As a workaround for #86 , we add enough storage for larger datasets on the integration tests for scaling and storage reuse.