### PR TITLE
fix(vm):  deflake the integration suite

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -248,7 +248,7 @@ jobs:
                 > ~/logs/"$name"-valkey-server.txt 2>&1
               { sudo juju ssh "$unit" "sudo cat $log_dir/sentinel.log"; } \
                 > ~/logs/"$name"-valkey-sentinel.txt 2>&1
-              { sudo juju ssh "$unit" 'sudo snap logs charmed-valkey.sentinel -n 500'; } \
+              { sudo juju ssh "$unit" 'sudo snap logs charmed-valkey -n 500'; } \
                 > ~/logs/"$name"-valkey-service.txt 2>&1
             done
           fi

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -196,6 +196,42 @@ jobs:
         timeout-minutes: 3
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: script -q -c 'sudo jhack tail --printer raw --replay --no-watch' /dev/null | tee ~/logs/jhack-tail.txt || true
+      - name: Capture Valkey server logs
+        timeout-minutes: 3
+        # Valkey and Sentinel log to files (config.py sets `logfile`), not stdout/journald,
+        # so `pebble logs` / `snap logs` miss them; read the files directly and keep a
+        # separate service-lifecycle capture. Best-effort -- never fail the job.
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        env:
+          SPREAD_JOB: ${{ matrix.job.spread_job }}
+        run: |
+          set +e
+          units=$(sudo juju status --format json 2>/dev/null | python3 -c \
+            "import json,sys; d=json.load(sys.stdin); print('\n'.join((d.get('applications',{}).get('valkey',{}).get('units') or {}).keys()))")
+          if [[ "$SPREAD_JOB" == *:tests/spread/k8s/* ]]; then
+            log_dir=/var/log/valkey
+            for unit in $units; do
+              pod=${unit/\//-}  # valkey/0 -> valkey-0
+              { sudo k8s kubectl -n testing exec "$pod" -c valkey -- \
+                cat "$log_dir/valkey.log"; } > ~/logs/"$pod"-valkey-server.txt 2>&1
+              { sudo k8s kubectl -n testing exec "$pod" -c valkey -- \
+                cat "$log_dir/sentinel.log"; } > ~/logs/"$pod"-valkey-sentinel.txt 2>&1
+              { sudo k8s kubectl -n testing exec "$pod" -c valkey -- \
+                pebble changes; } > ~/logs/"$pod"-valkey-service.txt 2>&1
+            done
+          else
+            log_dir=/var/snap/charmed-valkey/common/var/log/valkey
+            for unit in $units; do
+              name=${unit/\//-}
+              { sudo juju ssh "$unit" "sudo cat $log_dir/valkey.log"; } \
+                > ~/logs/"$name"-valkey-server.txt 2>&1
+              { sudo juju ssh "$unit" "sudo cat $log_dir/sentinel.log"; } \
+                > ~/logs/"$name"-valkey-sentinel.txt 2>&1
+              { sudo juju ssh "$unit" 'sudo snap logs charmed-valkey.sentinel -n 500'; } \
+                > ~/logs/"$name"-valkey-service.txt 2>&1
+            done
+          fi
+          true
       - name: Upload logs
         timeout-minutes: 5
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -23,9 +23,19 @@ jobs:
         uses: actions/checkout@v5
       - name: Set up environment
         run: |
+          # snapd intermittently cannot reach the store on a fresh runner
+          retry() {
+            for attempt in 1 2 3
+            do
+              "$@" && return 0
+              echo "::warning::'$*' failed (attempt $attempt of 3); retrying in 15s"
+              sleep 15
+            done
+            return 1
+          }
           sudo apt update
-          sudo snap install charmcraft --classic
-          sudo snap install go --classic
+          retry sudo snap install charmcraft --classic
+          retry sudo snap install go --classic
           go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
           # to build Valkey-glide during tests
@@ -136,11 +146,22 @@ jobs:
         timeout-minutes: 3
         uses: actions/checkout@v5
       - name: Set up environment
-        timeout-minutes: 5
+        # leaves room for the retry budget below on top of the ~3 min this step takes
+        timeout-minutes: 8
         run: |
+          # snapd intermittently cannot reach the store on a fresh runner
+          retry() {
+            for attempt in 1 2 3
+            do
+              "$@" && return 0
+              echo "::warning::'$*' failed (attempt $attempt of 3); retrying in 15s"
+              sleep 15
+            done
+            return 1
+          }
           sudo apt update
-          sudo snap install charmcraft --classic
-          sudo snap install go --classic
+          retry sudo snap install charmcraft --classic
+          retry sudo snap install go --classic
           go install github.com/canonical/spread/cmd/spread@latest
           # to build Valkey-glide during tests
           sudo apt install libprotobuf-dev protobuf-compiler -y

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,7 +28,18 @@ parts:
       PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.3  # renovate: charmcraft-pip-latest
 
       # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
-      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
+      # Retried whole: the download intermittently drops in CI, curl's --retry does not cover
+      # error 56, and a mid-transfer retry would replay the piped script from byte 0.
+      for attempt in 1 2 3
+      do
+        curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.9.5/uv-installer.sh | sh && break  # renovate: charmcraft-uv-latest
+        if [[ "$attempt" == 3 ]]
+        then
+          echo "uv installer download failed after 3 attempts" >&2
+          exit 1
+        fi
+        sleep 5
+      done
       # poetry 2.0.0 requires Python >=3.9
       if ! "$HOME/.local/bin/uv" python find '>=3.9'
       then

--- a/spread.yaml
+++ b/spread.yaml
@@ -125,8 +125,53 @@ prepare: |
 
   if [[ $SPREAD_SUITE == *"k8s"* ]]
   then
+    # Canonical K8s defaults its pod CIDR to 10.1.0.0/16 — the same range the GitHub-hosted
+    # Azure runners use for their host network, so a pod handed the subnet gateway address
+    # cannot reach the apiserver and its first hook dies. concierge has no pod-cidr option,
+    # but it adopts an already-clustered node, so bootstrap here first with a safe CIDR.
+    POD_CIDR="10.42.0.0/16"
+
+    # Fail loudly rather than re-introducing the flake if this ever collides again
+    NODE_IP="$(ip -4 route get 1.1.1.1 | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}')"
+    if [[ ${NODE_IP%.*.*} == "${POD_CIDR%%.0.0/*}" ]]
+    then
+      echo "pod CIDR $POD_CIDR contains this runner's own address $NODE_IP; pick another" >&2
+      exit 1
+    fi
+
+    if ! k8s status >/dev/null 2>&1
+    then
+      # Read the channel from concierge-k8s.yaml so the two cannot drift apart
+      K8S_CHANNEL="$(awk '/^ *k8s:/ {f = 1} f && /channel:/ {print $2; exit}' concierge-k8s.yaml)"
+      if [[ -z $K8S_CHANNEL ]]
+      then
+        echo "could not read the k8s channel from concierge-k8s.yaml" >&2
+        exit 1
+      fi
+      snap install k8s --classic --channel="$K8S_CHANNEL"
+
+      # The pre-init check refuses to bootstrap while Docker's /run/containerd exists;
+      # concierge does the same cleanup before its own bootstrap
+      systemctl stop containerd.service || true
+      rm -rf /run/containerd
+
+      # `k8s bootstrap --file` REPLACES the default cluster-config rather than merging, so
+      # the features a plain bootstrap enables must be spelled out; printf because a heredoc
+      # would carry the block scalar's indentation into the file
+      printf '%s\n' \
+        'cluster-config:' \
+        '  network: {enabled: true}' \
+        '  dns: {enabled: true}' \
+        '  local-storage: {enabled: true}' \
+        '  gateway: {enabled: true}' \
+        '  metrics-server: {enabled: true}' \
+        "pod-cidr: $POD_CIDR" \
+        > /tmp/k8s-bootstrap-config.yaml
+      k8s bootstrap --timeout 5m --file /tmp/k8s-bootstrap-config.yaml
+    fi
+
     concierge prepare --trace -c concierge-k8s.yaml
-  
+
     # k8s status --wait-ready returns as soon as 1 node is ready
     # (see https://github.com/canonical/k8s-snap/issues/1789)
     # but Cilium, CoreDNS, and storage may still be initialising

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -150,6 +150,7 @@ class PeerUnitModel(PeerModel):
     client_cert_ready: bool = Field(default=False)
     tls_ca_rotation: str = Field(default="")
     tls_certificate_expiring: bool = Field(default=False)
+    applied_client_cert_fingerprint: str = Field(default="")
     is_valkey_healthy: bool = Field(default=True)
     is_sentinel_healthy: bool = Field(default=True)
     client_user_epoch: float = Field(default=0)

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -396,10 +396,12 @@ class BaseEvents(ops.Object):
         if self.charm.state.substrate != Substrate.VM:
             return True
 
-        if not (
-            self.charm.state.unit_server.model.private_ip
-            and self.charm.state.bind_address != self.charm.state.unit_server.model.private_ip
-        ):
+        recorded_ip = self.charm.state.unit_server.model.private_ip
+        if not recorded_ip:
+            # the address is first recorded on start; there is nothing to reconcile before that
+            return True
+
+        if self.charm.state.bind_address == recorded_ip:
             return True
 
         try:

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -315,6 +315,11 @@ class BaseEvents(ops.Object):
             logger.warning("Service not started")
             return
 
+        # runs before the leader check (any unit's address can change) and is not
+        # deferred: update-status repeats on its own
+        if not self._reconcile_unit_address():
+            return
+
         if not self.charm.unit.is_leader():
             return
 
@@ -376,39 +381,63 @@ class BaseEvents(ops.Object):
         # update local unit admin password
         self.charm.auth_manager.update_local_valkey_admin_password()
 
-    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
-        """Handle the config_changed event."""
-        # on k8s we use hostnames so we do not have to reconfigure on ip change
-        if (
+    def _reconcile_unit_address(self) -> bool:
+        """Reconfigure the unit and reissue its certificate after its address changed.
+
+        When a machine changes address, Juju's binding may still report the old one while
+        `config-changed` runs, with no later `config-changed` to correct it — so
+        `update-status` must also converge the unit. The caller owns the retry strategy.
+
+        Returns:
+            bool: True if the address is reconciled (or there was nothing to do), False if
+                the reconcile could not complete and must be retried.
+        """
+        # on k8s we use hostnames, so the address is irrelevant and the binding unread
+        if self.charm.state.substrate != Substrate.VM:
+            return True
+
+        if not (
             self.charm.state.unit_server.model.private_ip
             and self.charm.state.bind_address != self.charm.state.unit_server.model.private_ip
-            and self.charm.state.substrate == Substrate.VM
         ):
-            try:
-                self.charm.auth_manager.configure_auth()
-                self.charm.config_manager.configure_services(
-                    self.charm.sentinel_manager.get_primary_ip()
-                )
-            except (ValkeyCannotGetPrimaryIPError, ValkeyConfigurationError) as e:
-                logger.error("Failed to configure auth and services: %s", e)
-                event.defer()
-                return
+            return True
+
+        try:
+            self.charm.auth_manager.configure_auth()
+            self.charm.config_manager.configure_services(
+                self.charm.sentinel_manager.get_primary_ip()
+            )
 
             if self.charm.tls_manager.certificate_sans_require_update():
                 if self.charm.state.client_tls_relation:
+                    # the provider owns the certificate; converge once it signs the new one
                     self.charm.tls_events.refresh_tls_certificates_event.emit()
-                    event.defer()
-                    return
+                    return False
 
                 self.charm.tls_manager.create_and_store_self_signed_certificate()
+        except (
+            ValkeyCannotGetPrimaryIPError,
+            ValkeyConfigurationError,
+            ValkeyWorkloadCommandError,
+        ) as e:
+            logger.error("Failed to reconcile the unit address: %s", e)
+            return False
 
-            self.charm.state.unit_server.update(
-                {
-                    "hostname": self.charm.state.hostname,
-                    "private_ip": self.charm.state.bind_address,
-                }
-            )
-            self.charm.restart_workload.emit()
+        self.charm.state.unit_server.update(
+            {
+                "hostname": self.charm.state.hostname,
+                "private_ip": self.charm.state.bind_address,
+            }
+        )
+        self.charm.restart_workload.emit()
+        return True
+
+    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
+        """Handle the config_changed event."""
+        if not self._reconcile_unit_address():
+            # config-changed does not repeat on its own, so the reconcile must be retried
+            event.defer()
+            return
 
         if not self.charm.unit.is_leader():
             return

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -177,6 +177,10 @@ class TLSEvents(ops.Object):
             logger.error("Received certificate does not match provided certificates: %s", cert)
             return
 
+        if self.charm.tls_manager.certificate_already_applied(cert):
+            logger.debug("Client certificate unchanged and already active, nothing to do")
+            return
+
         logger.info("Storing client certificate")
         try:
             if rotate_ca := self.charm.tls_manager.start_ca_rotation_if_required(cert):
@@ -193,12 +197,16 @@ class TLSEvents(ops.Object):
             try:
                 if rotate_ca:
                     self.charm.tls_manager.set_ca_rotation_state(TLSCARotationState.NEW_CA_ADDED)
+                    # safe before orchestration: the skip guard is inert while
+                    # tls_ca_rotation is not NO_ROTATION
+                    self.charm.tls_manager.record_applied_certificate(cert)
                     self._orchestrate_ca_rotation()
                     return
 
                 tls_config = self.charm.config_manager.generate_tls_config()
                 self.charm.cluster_manager.reload_tls_settings(tls_config)
                 self.charm.restart_workload.emit(restart_valkey=False, restart_sentinel=True)
+                self.charm.tls_manager.record_applied_certificate(cert)
             except ValkeyCertificatesNotReadyError:
                 logger.debug("Not all units ready")
             except (ValkeyTLSLoadError, ValkeyWorkloadCommandError):
@@ -240,6 +248,7 @@ class TLSEvents(ops.Object):
             self.charm.restart_workload.emit(
                 restart_valkey=False, restart_sentinel=True, primary_endpoint=primary_ip
             )
+        self.charm.tls_manager.record_applied_certificate(cert)
         self._trigger_relation_change_if_required()
 
     def _on_certificate_denied(self, event: CertificateDeniedEvent) -> None:

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -9,6 +9,7 @@ import binascii
 import logging
 import re
 from datetime import timedelta
+from hashlib import sha256
 from ipaddress import ip_address
 
 from charmlibs.interfaces.tls_certificates import (
@@ -72,6 +73,38 @@ class TLSManager(ManagerStatusProtocol):
         """
         logger.debug(f"Setting TLS CA rotation state to {state}")
         self.state.unit_server.update({"tls_ca_rotation": state.value})
+
+    def client_cert_fingerprint(self, certificate: ProviderCertificate) -> str:
+        """Return a stable fingerprint for a client certificate + CA pair."""
+        return sha256((certificate.certificate.raw + certificate.ca.raw).encode()).hexdigest()
+
+    def certificate_already_applied(self, certificate: ProviderCertificate) -> bool:
+        """Return whether this exact certificate is stored AND fully activated on this unit.
+
+        The tls-certificates lib re-emits ``certificate_available`` for an
+        unchanged certificate on every relation-changed of the (app-shared)
+        client-certificates relation, so requirers must be idempotent.
+
+        The fingerprint is recorded only once an apply has been handed off
+        (restart emitted, or CA rotation started — the rotation state machine
+        owns activation from there), so a deferred/failed apply is still
+        retried instead of being skipped.
+        """
+        if self.state.unit_server.tls_client_state != TLSState.TLS:
+            return False
+        if self.state.unit_server.tls_ca_rotation_state != TLSCARotationState.NO_ROTATION:
+            return False
+        if not self.state.unit_server.model.client_cert_ready:
+            return False
+        return self.state.unit_server.model.applied_client_cert_fingerprint == (
+            self.client_cert_fingerprint(certificate)
+        )
+
+    def record_applied_certificate(self, certificate: ProviderCertificate) -> None:
+        """Record the certificate as applied, enabling the skip on re-emission."""
+        self.state.unit_server.update(
+            {"applied_client_cert_fingerprint": self.client_cert_fingerprint(certificate)}
+        )
 
     def write_certificate(self, certificate: ProviderCertificate, private_key: PrivateKey) -> None:
         """Store the certificate on the unit.

--- a/tests/integration/clients/test_client_relation.py
+++ b/tests/integration/clients/test_client_relation.py
@@ -19,6 +19,7 @@ import pytest
 from literals import CharmUsers, Substrate
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_TLS_S,
     IMAGE_RESOURCE,
     TLS_CHANNEL,
     TLS_NAME,
@@ -248,7 +249,7 @@ def test_enable_tls(juju: jubilant.Juju) -> None:
     juju.integrate(f"{REQUIRER_V1_NAME}:certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Ensure TLS access for v0 client")

--- a/tests/integration/clients/test_client_relation.py
+++ b/tests/integration/clients/test_client_relation.py
@@ -27,6 +27,8 @@ from tests.integration.helpers import (
     exec_valkey_cli,
     get_cluster_addresses,
     get_password,
+    get_primary_ip,
+    wait_for_failover,
 )
 
 logger = logging.getLogger(__name__)
@@ -173,6 +175,7 @@ def test_integrate_client_interface_v1(juju: jubilant.Juju) -> None:
 def test_failover_topology_update(juju: jubilant.Juju) -> None:
     """Trigger a failover and ensure clients can still access Valkey."""
     ip_address = get_cluster_addresses(juju, APP_NAME)[0]
+    old_primary_ip = get_primary_ip(juju, APP_NAME)
     logger.info("Initiate failover through Sentinel %s", ip_address)
 
     failover_result = exec_valkey_cli(
@@ -184,6 +187,8 @@ def test_failover_topology_update(juju: jubilant.Juju) -> None:
         sentinel=True,
     ).stdout
     assert failover_result == "OK", "Failover not successful"
+
+    wait_for_failover(juju, APP_NAME, old_primary_ip=old_primary_ip, unit_count=NUM_UNITS)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=60, unit_count=NUM_UNITS),
         timeout=600,

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -4,10 +4,10 @@
 
 """High availability helpers."""
 
+import base64
 import os
 import string
 import subprocess
-import tarfile
 import tempfile
 import time
 from datetime import datetime
@@ -539,6 +539,34 @@ def lxd_patch_restart_delay(juju: jubilant.Juju, unit_name: str, delay: int | No
     juju.exec(command="sudo systemctl daemon-reload", unit=unit_name)
 
 
+def _pod_exec(
+    kube_client: client.api.core_v1_api.CoreV1Api,
+    namespace: str,
+    pod_name: str,
+    container_name: str,
+    command: list[str],
+    timeout: int = 30,
+) -> tuple[int | None, str]:
+    """Run a command in a pod container and return (returncode, combined output).
+
+    A returncode of None means the command did not complete within the timeout.
+    """
+    response = stream.stream(
+        kube_client.connect_get_namespaced_pod_exec,
+        pod_name,
+        namespace,
+        container=container_name,
+        command=command,
+        stdin=False,
+        stdout=True,
+        stderr=True,
+        tty=False,
+        _preload_content=False,
+    )
+    response.run_forever(timeout=timeout)
+    return response.returncode, response.read_all()
+
+
 def pebble_patch_restart_delay(
     juju: jubilant.Juju,
     unit_name: str,
@@ -564,117 +592,54 @@ def pebble_patch_restart_delay(
     pod_name = unit_name.replace("/", "-")
     container_name = "valkey"
     service_name = "valkey"
-    now = datetime.now().isoformat()
+    layer_path = f"/tmp/pebble_plan_{datetime.now().isoformat()}.yml"
 
-    with tempfile.NamedTemporaryFile() as pebble_plan_file:
-        pebble_plan_file.write(str.encode(pebble_file_content))
-        pebble_plan_file.flush()
-
-        copy_file_into_pod(
-            kube_client,
-            juju.model,
-            pod_name,
-            container_name,
-            pebble_plan_file.name,
-            f"/tmp/pebble_plan_{now}.yml",
-        )
-
-    add_to_pebble_layer_commands = (
-        f"/charm/bin/pebble add --combine {service_name} /tmp/pebble_plan_{now}.yml"
-    )
-    response = stream.stream(
-        kube_client.connect_get_namespaced_pod_exec,
-        pod_name,
-        juju.model,
-        container=container_name,
-        command=add_to_pebble_layer_commands.split(),
-        stdin=False,
-        stdout=True,
-        stderr=True,
-        tty=False,
-        _preload_content=False,
-    )
-    response.run_forever(timeout=5)
-    assert response.returncode == 0, (
-        f"Failed to add to pebble layer, unit={unit_name}, container={container_name}, service={service_name}"
-    )
-
-    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+    # A one-shot base64 write avoids the tar-over-stdin websocket dance, whose
+    # close() raced tar's read and could leave a truncated layer file behind.
+    encoded = base64.b64encode(pebble_file_content.encode()).decode()
+    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
         with attempt:
-            replan_pebble_layer_commands = "/charm/bin/pebble replan"
-            response = stream.stream(
-                kube_client.connect_get_namespaced_pod_exec,
-                pod_name,
+            returncode, output = _pod_exec(
+                kube_client,
                 juju.model,
-                container=container_name,
-                command=replan_pebble_layer_commands.split(),
-                stdin=False,
-                stdout=True,
-                stderr=True,
-                tty=False,
-                _preload_content=False,
+                pod_name,
+                container_name,
+                ["sh", "-c", f"echo {encoded} | base64 -d > {layer_path}"],
             )
-            response.run_forever(timeout=60)
+            assert returncode == 0, (
+                f"Failed to write pebble layer file, unit={unit_name}, "
+                f"container={container_name}, returncode={returncode}, output={output!r}"
+            )
+
+            returncode, output = _pod_exec(
+                kube_client,
+                juju.model,
+                pod_name,
+                container_name,
+                ["/charm/bin/pebble", "add", "--combine", service_name, layer_path],
+            )
+            assert returncode == 0, (
+                f"Failed to add to pebble layer, unit={unit_name}, "
+                f"container={container_name}, service={service_name}, "
+                f"returncode={returncode}, output={output!r}"
+            )
+
+    for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
+        with attempt:
+            returncode, output = _pod_exec(
+                kube_client,
+                juju.model,
+                pod_name,
+                container_name,
+                ["/charm/bin/pebble", "replan"],
+                timeout=60,
+            )
             if ensure_replan:
-                assert response.returncode == 0, (
-                    f"Failed to replan pebble layer, unit={unit_name}, container={container_name}, service={service_name}"
+                assert returncode == 0, (
+                    f"Failed to replan pebble layer, unit={unit_name}, "
+                    f"container={container_name}, service={service_name}, "
+                    f"returncode={returncode}, output={output!r}"
                 )
-
-
-def copy_file_into_pod(
-    client: client.api.core_v1_api.CoreV1Api,
-    namespace: str,
-    pod_name: str,
-    container_name: str,
-    source_path: str,
-    destination_path: str,
-) -> None:
-    """Copy file contents into pod.
-
-    Args:
-        client: The kubernetes CoreV1Api client
-        namespace: The namespace of the pod to copy files to
-        pod_name: The name of the pod to copy files to
-        container_name: The name of the pod container to copy files to
-        source_path: The path of the file to copy from the local machine
-        destination_path: The path to copy the file to in the pod
-    """
-    try:
-        exec_command = ["tar", "xvf", "-", "-C", "/"]
-
-        api_response = stream.stream(
-            client.connect_get_namespaced_pod_exec,
-            pod_name,
-            namespace,
-            container=container_name,
-            command=exec_command,
-            stdin=True,
-            stdout=True,
-            stderr=True,
-            tty=False,
-            _preload_content=False,
-        )
-
-        with tempfile.TemporaryFile() as tar_buffer:
-            with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
-                tar.add(source_path, destination_path)
-
-            tar_buffer.seek(0)
-            commands = []
-            commands.append(tar_buffer.read())
-
-            while api_response.is_open():
-                api_response.update(timeout=1)
-
-                if commands:
-                    command = commands.pop(0)
-                    api_response.write_stdin(command.decode())
-                else:
-                    break
-
-            api_response.close()
-    except ApiException:
-        assert False
 
 
 def patch_restart_delay(

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -489,10 +489,15 @@ def is_endpoint_in_sentinels(
     tls_enabled: bool = False,
 ) -> bool:
     """Check if the provided endpoint is present in the sentinels list of any of the provided hostnames."""
+    # Sentinel announces bare IPs on VM and FQDNs on K8s (`<pod>.<app>-endpoints.<ns>.svc...`),
+    # so accept the endpoint itself or the endpoint as a leading DNS label. A plain substring
+    # test is not enough: on VM, "10.70.115.24" is a prefix of a peer at "10.70.115.248", and
+    # `SENTINEL SENTINELS` iterates a hash dict, so the peer can be the first "match" and its
+    # flags get checked instead of the old primary's.
     endpoint_sentinel = [
         sentinel
         for sentinel in get_sentinels(juju, primary_ip=hostname, tls_enabled=tls_enabled)
-        if endpoint in sentinel["ip"]
+        if sentinel["ip"] == endpoint or sentinel["ip"].startswith(f"{endpoint}.")
     ]
     if not endpoint_sentinel:
         logger.error(

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -30,6 +30,10 @@ VM_RESTART_DELAY_DEFAULT = 20
 K8S_RESTART_DELAY_DEFAULT = 5
 RESTART_DELAY_PATCHED = 120
 
+# Budget for a whole `juju ssh` round trip (CLI start-up, controller API, SSH handshake,
+# `sudo -i` on VM); the remote commands themselves are instantaneous, so this is a hang guard.
+SSH_COMMAND_TIMEOUT = 60
+
 
 EXTEND_PEBBLE_RESTART_DELAY_YAML = """services:
   valkey:
@@ -495,9 +499,25 @@ def send_process_control_signal(
 
     try:
         subprocess.check_output(
-            command, stderr=subprocess.PIPE, shell=True, universal_newlines=True, timeout=3
+            command,
+            stderr=subprocess.PIPE,
+            shell=True,
+            universal_newlines=True,
+            timeout=SSH_COMMAND_TIMEOUT,
         )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+    except subprocess.TimeoutExpired as e:
+        # only the local `juju ssh` was killed -- the remote pkill may have run already
+        logger.error(
+            "`juju ssh` did not return within %ss while sending %s to %s on unit %s; "
+            "the signal may or may not have been delivered",
+            SSH_COMMAND_TIMEOUT,
+            signal,
+            db_process,
+            unit_name,
+        )
+        logger.error("Error details: %s", e)
+        raise
+    except subprocess.CalledProcessError as e:
         logger.error(
             "failed to send signal %s to process %s on unit %s", signal, db_process, unit_name
         )

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -45,6 +45,16 @@ RESTORE_PEBBLE_RESTART_DELAY_YAML = """services:
     backoff-limit: 30s
 """
 
+# Cut the network without changing the unit's IP by dropping packets inside the container:
+# masking the NIC (the ip_change path) drops the DHCP lease, and a bandwidth throttle (what
+# this used to do) still lets Sentinel PING/PONG trickle through, so +odown never reaches
+# quorum and no failover starts. Loopback stays open for the charm's own health checks;
+# `lxc exec` rides the LXD socket, so cut and restore work while the container is isolated.
+NETWORK_CUT_RULES = (
+    "INPUT ! --in-interface lo --jump DROP",
+    "OUTPUT ! --out-interface lo --jump DROP",
+)
+
 
 def lxd_cut_network_from_unit_with_ip_change(machine_name: str) -> None:
     """Cut network from a lxc container in a way the changes the IP."""
@@ -55,21 +65,29 @@ def lxd_cut_network_from_unit_with_ip_change(machine_name: str) -> None:
     time.sleep(5)
 
 
+def _lxd_delete_iptables_rule(machine_name: str, rule: str) -> bool:
+    """Delete an iptables rule inside an lxc container, reporting whether it was there."""
+    command = f"lxc exec {machine_name} -- iptables --delete {rule}"
+    returncode = subprocess.call(
+        command.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    return returncode == 0
+
+
 def lxd_cut_network_from_unit_without_ip_change(machine_name: str) -> None:
     """Cut network from a lxc container (without causing the change of the unit IP address)."""
-    override_command = f"lxc config device override {machine_name} eth0"
-    try:
-        subprocess.check_call(override_command.split())
-    except subprocess.CalledProcessError:
-        # Ignore if the interface was already overridden.
-        pass
+    for rule in NETWORK_CUT_RULES:
+        # drop a leftover copy first so re-cutting cannot stack a duplicate rule
+        _lxd_delete_iptables_rule(machine_name, rule)
+        subprocess.check_call(f"lxc exec {machine_name} -- iptables --insert {rule}".split())
 
-    limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress=0kbit"
-    subprocess.check_call(limit_set_command.split())
-    limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress=1kbit"
-    subprocess.check_call(limit_set_command.split())
-    limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority=10"
-    subprocess.check_call(limit_set_command.split())
+
+def lxd_restore_network_to_unit_without_ip_change(machine_name: str) -> None:
+    """Restore the network of a lxc container that was cut without an IP address change."""
+    for rule in NETWORK_CUT_RULES:
+        # tolerate a missing rule so restoring twice is a no-op
+        if not _lxd_delete_iptables_rule(machine_name, rule):
+            logger.warning("iptables rule %r was not present on %s", rule, machine_name)
 
 
 def k8s_cut_network_from_unit_without_ip_change(model_name: str, machine_name: str) -> None:
@@ -155,12 +173,7 @@ def restore_network_to_unit(
             restore_network_command = f"lxc config device remove {machine_name} eth0"
             subprocess.check_call(restore_network_command.split())
             return
-        limit_set_command = f"lxc config device set {machine_name} eth0 limits.egress="
-        subprocess.check_call(limit_set_command.split())
-        limit_set_command = f"lxc config device set {machine_name} eth0 limits.ingress="
-        subprocess.check_call(limit_set_command.split())
-        limit_set_command = f"lxc config device set {machine_name} eth0 limits.priority="
-        subprocess.check_call(limit_set_command.split())
+        lxd_restore_network_to_unit_without_ip_change(machine_name)
     else:
         env = os.environ
         env["KUBECONFIG"] = os.path.expanduser("~/.kube/config")

--- a/tests/integration/ha/helpers/helpers.py
+++ b/tests/integration/ha/helpers/helpers.py
@@ -5,6 +5,7 @@
 """High availability helpers."""
 
 import base64
+import json
 import os
 import string
 import subprocess
@@ -137,6 +138,38 @@ def k8s_cut_network_from_unit_without_ip_change(model_name: str, machine_name: s
                     )
                     raise
         logger.info("Result of isolating unit from cluster is '%s'", command_result)
+
+        # `kubectl apply` only means the API server accepted the NetworkChaos; chaos-mesh
+        # programs the netem rule asynchronously (NetworkChaos -> PodNetworkChaos ->
+        # chaos-daemon), which can take longer than the reachability probe's pod start-up.
+        # Wait until chaos-mesh reports the rule injected before returning, so the "cut" is
+        # synchronous like the LXD iptables variant.
+        _k8s_wait_network_chaos_injected(model_name)
+
+
+def _k8s_wait_network_chaos_injected(namespace: str) -> None:
+    """Block until the `network-loss-primary` NetworkChaos is selected and fully injected.
+
+    Chaos-mesh only flips a record to `Injected` after the daemon applied the tc rule
+    (PodNetworkChaos `observedGeneration` catches up), so `AllInjected=True` is the real
+    "packets are being dropped" signal. `Selected=True` is required as well: before any pod
+    is selected the record loop is empty and `AllInjected` is vacuously True.
+    """
+    for attempt in Retrying(stop=stop_after_delay(120), wait=wait_fixed(2), reraise=True):
+        with attempt:
+            output = subprocess.check_output(
+                f"sudo k8s kubectl -n {namespace} get networkchaos network-loss-primary -o json",
+                shell=True,
+                env=os.environ,
+                stderr=subprocess.STDOUT,
+            )
+            conditions = {
+                cond["type"]: cond["status"]
+                for cond in json.loads(output).get("status", {}).get("conditions", [])
+            }
+            if conditions.get("Selected") != "True" or conditions.get("AllInjected") != "True":
+                raise ValueError(f"network chaos not injected yet: {conditions}")
+            logger.info("Network chaos injected: %s", conditions)
 
 
 def cut_network_from_unit(

--- a/tests/integration/ha/test_failover.py
+++ b/tests/integration/ha/test_failover.py
@@ -30,6 +30,8 @@ from tests.integration.ha.helpers.helpers import (
 
 from ..helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_S,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CHANNEL,
@@ -85,7 +87,7 @@ def test_build_and_deploy(
         lambda status: are_apps_active_and_agents_idle(
             status, APP_NAME, GLIDE_RUNNER_NAME, idle_period=30
         ),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S if tls_enabled else DEPLOY_TIMEOUT_S,
     )
 
     assert len(juju.status().apps[APP_NAME].units) == NUM_UNITS, (

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -35,6 +35,7 @@ from tests.integration.helpers import (
     TLS_NAME,
     are_apps_active_and_agents_idle,
     download_client_certificate_from_unit,
+    fast_forward,
     get_cluster_addresses,
     get_ip_from_unit,
     get_number_connected_replicas,
@@ -250,19 +251,25 @@ def test_network_cut_primary(  # noqa: C901
 
     # we do not use IPs in certificates for k8s, so no need to check SANs for IP changes
     if substrate == Substrate.VM:
-        # read ip from cert and check if is a different ip than before if ip_change is True
-        # tolerate delays in certificate update by retrying for up to 100 seconds with 10 second intervals
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(10), reraise=True):
-            with attempt:
-                download_client_certificate_from_unit(juju, APP_NAME, unit_name=primary_unit_name)
-                certificate_sans = get_sans_from_certificate("./client.pem")
-                if ip_change:
-                    assert primary_ip not in certificate_sans["sans_ip"], (
-                        "The old IP should not be in SANs of client certificate after network cut and IP change."
+        # The address reconcile runs from update-status (the binding can still report the old
+        # IP during the post-restore config-changed), so fast-forward the interval to land it
+        # within the 100s of retries below.
+        with fast_forward(juju):
+            for attempt in Retrying(
+                stop=stop_after_attempt(10), wait=wait_fixed(10), reraise=True
+            ):
+                with attempt:
+                    download_client_certificate_from_unit(
+                        juju, APP_NAME, unit_name=primary_unit_name
                     )
-                    assert new_unit_ip in certificate_sans["sans_ip"], (
-                        "The new IP should be in SANs of client certificate after network cut and IP change."
-                    )
+                    certificate_sans = get_sans_from_certificate("./client.pem")
+                    if ip_change:
+                        assert primary_ip not in certificate_sans["sans_ip"], (
+                            "The old IP should not be in SANs of client certificate after network cut and IP change."
+                        )
+                        assert new_unit_ip in certificate_sans["sans_ip"], (
+                            "The new IP should be in SANs of client certificate after network cut and IP change."
+                        )
 
     addresses = get_cluster_addresses(juju, APP_NAME)
     # check replica number that it is back to NUM_UNITS - 1

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -93,6 +93,15 @@ def test_network_cut_primary(  # noqa: C901
     if ip_change and substrate == Substrate.K8S:
         pytest.skip("Changing IP is not applicable for k8s substrate.")
 
+    # The parametrized cases share one model, and the previous case's restore can still be
+    # driving a rolling Sentinel restart — let the cluster settle before cutting again.
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(
+            status, APP_NAME, GLIDE_RUNNER_NAME, idle_period=30
+        ),
+        timeout=DEPLOY_TIMEOUT_S,
+    )
+
     download_client_certificate_from_unit(juju, APP_NAME)
     addresses = get_cluster_addresses(juju, APP_NAME)
 
@@ -146,10 +155,9 @@ def test_network_cut_primary(  # noqa: C901
     logger.info("Verifying new primary election...")
 
     new_primary_ip = None
-    # Sentinel only marks the old primary down after `down-after-milliseconds` (30s,
-    # see src/managers/config.py) and then needs time to reach quorum and promote a
-    # replica, so a new primary cannot appear before ~30s. Wait well past that (but
-    # under the 180s `failover-timeout`) to absorb CI scheduling jitter.
+    # Sentinel marks the primary down only after `down-after-milliseconds` (30s) and must
+    # then reach quorum and promote; the effective `failover-timeout` is 60s (both set in
+    # src/managers/config.py), so 150s spans ~2 failover attempts plus CI jitter.
     for attempt in Retrying(stop=stop_after_attempt(15), wait=wait_fixed(10), reraise=True):
         with attempt:
             try:

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -27,6 +27,8 @@ from tests.integration.ha.helpers.helpers import (
 )
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_S,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CHANNEL,
@@ -69,7 +71,7 @@ def test_build_and_deploy(
         lambda status: are_apps_active_and_agents_idle(
             status, APP_NAME, GLIDE_RUNNER_NAME, idle_period=30
         ),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S if tls_enabled else DEPLOY_TIMEOUT_S,
     )
 
     assert len(juju.status().apps[APP_NAME].units) == NUM_UNITS, (

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -44,6 +44,11 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME: str = METADATA["name"]
 GLIDE_RUNNER_NAME = "glide-runner"
 IMAGE_RESOURCE = {"valkey-image": METADATA["resources"]["valkey-image"]["upstream-source"]}
+# DEPLOY_TIMEOUT_TLS_S covers any wait that spans a client-TLS enable: applying the client
+# certificate takes a rolling sentinel restart serialized by RestartLock, whose handoffs
+# alone take ~6-9 min for three units on a loaded runner.
+DEPLOY_TIMEOUT_S = 600
+DEPLOY_TIMEOUT_TLS_S = 900
 INTERNAL_USERS_SECRET_LABEL = (
     f"{PEER_RELATION}.{APP_NAME}.app.{INTERNAL_USERS_SECRET_LABEL_SUFFIX}"
 )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -23,6 +23,7 @@ from glide import (
     TlsAdvancedConfiguration,
 )
 from ops import SecretNotFoundError, StatusBase
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from literals import (
     CLIENT_PORT,
@@ -409,6 +410,79 @@ def get_primary_ip(
             logger.warning(f"Error executing Valkey CLI on {address}: {e}")
 
     raise ValueError("No primary node found in the cluster")
+
+
+def get_connected_replicas_from_unit(
+    juju: jubilant.Juju, address: str, tls_enabled: bool = False
+) -> int:
+    """Get the number of replicas connected to the Valkey node at `address`.
+
+    Unlike `get_number_connected_replicas`, this queries the node directly with `valkey-cli`,
+    so it is usable in suites that do not deploy the glide-runner.
+
+    Args:
+        juju: The Juju client instance.
+        address: The address of the node to query.
+        tls_enabled: Whether TLS certificates are needed.
+
+    Returns:
+        The number of replicas connected to that node.
+    """
+    replication_info = exec_valkey_cli(
+        address,
+        username=CharmUsers.VALKEY_ADMIN.value,
+        password=get_password(juju),
+        command="info replication",
+        tls_enabled=tls_enabled,
+    ).stdout
+    if not (search_result := re.search(r"connected_slaves:(\d+)", replication_info)):
+        raise ValueError("Could not parse number of connected replicas from info output")
+    return int(search_result.group(1))
+
+
+def wait_for_failover(
+    juju: jubilant.Juju,
+    app: str,
+    old_primary_ip: str,
+    unit_count: int,
+    tls_enabled: bool = False,
+    timeout: int = 300,
+) -> str:
+    """Block until Sentinel has finished a failover and every replica is re-attached.
+
+    `sentinel failover` returns `OK` as soon as the failover is *initiated*: until the old
+    primary is demoted and re-attached, writes routed to it fail with `NOREPLICAS` and the
+    published client endpoints may still point at it. Idle agents indicate none of this,
+    so poll the cluster itself.
+
+    Args:
+        juju: The Juju client instance.
+        app: The name of the Valkey application.
+        old_primary_ip: Address of the primary as it was before the failover.
+        unit_count: The number of Valkey units in the cluster.
+        tls_enabled: Whether TLS certificates are needed.
+        timeout: Seconds to wait for the cluster to converge.
+
+    Returns:
+        The address of the new primary.
+    """
+    new_primary_ip = ""
+    for attempt in Retrying(stop=stop_after_delay(timeout), wait=wait_fixed(10), reraise=True):
+        with attempt:
+            new_primary_ip = get_primary_ip(juju, app, tls_enabled=tls_enabled)
+            assert new_primary_ip != old_primary_ip, (
+                f"Primary is still {old_primary_ip}, failover has not completed yet."
+            )
+            connected_replicas = get_connected_replicas_from_unit(
+                juju, new_primary_ip, tls_enabled=tls_enabled
+            )
+            assert connected_replicas == unit_count - 1, (
+                f"Expected {unit_count - 1} replicas connected to the new primary"
+                f" {new_primary_ip}, got {connected_replicas}."
+            )
+
+    logger.info("Failover complete, new primary is %s (was %s)", new_primary_ip, old_primary_ip)
+    return new_primary_ip
 
 
 def get_password(juju: jubilant.Juju, user: CharmUsers = CharmUsers.VALKEY_ADMIN) -> str:

--- a/tests/integration/tls/test_certificate_options.py
+++ b/tests/integration/tls/test_certificate_options.py
@@ -13,6 +13,7 @@ from literals import CharmUsers, Substrate
 from statuses import TLSStatuses
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CERT_FILE,
@@ -71,7 +72,7 @@ def test_build_and_deploy(
             idle_period=30,
             unit_count={APP_NAME: NUM_UNITS, GLIDE_RUNNER_NAME: 1},
         ),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
     juju.wait(lambda status: jubilant.all_blocked(status, VAULT_NAME))
 

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -3,8 +3,10 @@
 # See LICENSE file for licensing details.
 import logging
 from time import monotonic, sleep
+from typing import NamedTuple
 
 import jubilant
+import pytest
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from literals import CharmUsers, Substrate
@@ -35,13 +37,62 @@ NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
 CERTIFICATE_EXPIRY_TIME = 600
-# The provider renews a CA `certificate-validity` before it expires, i.e. 15 min after the CA
-# rotation test configures a 25 min CA with 10 min certificates, and the units pick the new CA up
-# at their next certificate renewal (every 0.6 x 10 min = 6 min): +18 min after that config,
-# safely after test_ca_rotation_by_config_change finished (its waits are bounded to +15 min) and
-# 3 min clear of the neighbouring renewals either side of the CA renewal.
+# The provider renews a CA `certificate-validity` before it expires, i.e. 15 min after the
+# `rotated_ca` fixture configures a 25 min CA with 10 min certificates, and the units pick the new
+# CA up at their next certificate renewal (every 0.6 x 10 min = 6 min): +18 min after that config,
+# safely after the fixture finished (its wait is bounded to +15 min) and 3 min clear of the
+# neighbouring renewals either side of the CA renewal.
 CA_EXPIRY_TIME = 1080
-_ca_rotation_config_time = 0.0
+
+
+class CARotation(NamedTuple):
+    """The CA rotation performed by the `rotated_ca` fixture, and the material either side of it."""
+
+    config_time: float
+    """`monotonic()` when the provider was reconfigured, i.e. when the CA clocks started."""
+    old_ca: str
+    old_certificate: str
+    new_ca: str
+    new_certificate: str
+
+
+@pytest.fixture(scope="module")
+def rotated_ca(juju: jubilant.Juju) -> CARotation:
+    """Rotate the CA on the provider, capturing the material either side of the rotation.
+
+    Module-scoped, so both CA rotation tests share one rotation: the short CA validity configured
+    here also schedules the provider-side CA renewal that `test_ca_rotation_by_expiration` waits
+    for, so that test does not have to rotate the CA a second time first - which would add ~15 min
+    to a job that already runs close to the 75 min CI limit.
+    """
+    logger.info("Getting the current CA certificates")
+    download_client_certificate_from_unit(juju, APP_NAME)
+    with open(TLS_CA_FILE, "r") as ca_file:
+        old_ca = ca_file.read()
+    with open(TLS_CERT_FILE, "r") as cert_file:
+        old_certificate = cert_file.read()
+
+    logger.info("Rotating the CA certificate")
+    tls_config = {
+        "certificate-validity": "10m",
+        "root-ca-validity": "25m",
+        "ca-common-name": "new-valkey-ca",
+    }
+    config_time = monotonic()
+    juju.config(app=TLS_NAME, values=tls_config)
+    juju.wait(
+        lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
+        timeout=DEPLOY_TIMEOUT_TLS_S,
+    )
+
+    logger.info("Getting the rotated CA certificates")
+    download_client_certificate_from_unit(juju, APP_NAME)
+    with open(TLS_CA_FILE, "r") as ca_file:
+        new_ca = ca_file.read()
+    with open(TLS_CERT_FILE, "r") as cert_file:
+        new_certificate = cert_file.read()
+
+    return CARotation(config_time, old_ca, old_certificate, new_ca, new_certificate)
 
 
 def _prepare_units_for_ca_expiration_test(juju: jubilant.Juju, substrate: Substrate) -> None:
@@ -193,48 +244,20 @@ def test_certificate_expiration(juju: jubilant.Juju, substrate: Substrate) -> No
     )
 
 
-def test_ca_rotation_by_config_change(juju: jubilant.Juju) -> None:
+def test_ca_rotation_by_config_change(juju: jubilant.Juju, rotated_ca: CARotation) -> None:
     """Test the CA rotation.
 
     The CA certificate should be rotated and the cluster should still be accessible.
     The rotation is triggered by updating the config for `ca-common-name` on the TLS provider side.
     """
-    # Rotate the CA certificate
-    logger.info("Getting the current CA certificates")
-    download_client_certificate_from_unit(juju, APP_NAME)
-    with open(TLS_CA_FILE, "r") as ca_file:
-        old_ca_certificate = ca_file.read()
-    assert old_ca_certificate, "Failed to get current ca certificate"
-    with open(TLS_CERT_FILE, "r") as cert_file:
-        old_certificate = cert_file.read()
-    assert old_certificate, "Failed to get current certificate"
-
-    logger.info("Rotating the CA certificate")
-    # The short CA validity schedules the provider-side CA renewal test_ca_rotation_by_expiration
-    # waits for, so that test does not need to rotate the CA a second time first.
-    tls_config = {
-        "certificate-validity": "10m",
-        "root-ca-validity": "25m",
-        "ca-common-name": "new-valkey-ca",
-    }
-    global _ca_rotation_config_time
-    _ca_rotation_config_time = monotonic()
-    juju.config(app=TLS_NAME, values=tls_config)
-    juju.wait(
-        lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=DEPLOY_TIMEOUT_TLS_S,
-    )
+    assert rotated_ca.old_ca, "Failed to get current ca certificate"
+    assert rotated_ca.old_certificate, "Failed to get current certificate"
 
     logger.info("Checking if the CA certificates are rotated")
-    download_client_certificate_from_unit(juju, APP_NAME)
-    with open(TLS_CA_FILE, "r") as ca_file:
-        new_ca_certificate = ca_file.read()
-    assert new_ca_certificate, "Failed to get updated ca certificate"
-    with open(TLS_CERT_FILE, "r") as cert_file:
-        new_certificate = cert_file.read()
-    assert new_certificate, "Failed to get updated certificate"
-    assert old_ca_certificate != new_ca_certificate, "CA certificate was not updated"
-    assert old_certificate != new_certificate, "Certificate was not updated"
+    assert rotated_ca.new_ca, "Failed to get updated ca certificate"
+    assert rotated_ca.new_certificate, "Failed to get updated certificate"
+    assert rotated_ca.old_ca != rotated_ca.new_ca, "CA certificate was not updated"
+    assert rotated_ca.old_certificate != rotated_ca.new_certificate, "Certificate was not updated"
 
     logger.info("Check access with updated certificate")
     endpoints = get_cluster_endpoints(juju, APP_NAME)
@@ -262,19 +285,17 @@ def test_ca_rotation_by_config_change(juju: jubilant.Juju) -> None:
     ), "Failed to read data with updated certificate"
 
 
-def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
+def test_ca_rotation_by_expiration(juju: jubilant.Juju, rotated_ca: CARotation) -> None:
     """Test the CA rotation.
 
     The CA certificate should be rotated and the cluster should still be accessible.
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
-    # The CA and certificate validity were configured by test_ca_rotation_by_config_change; the
-    # material it downloaded last is still the current one and predates the CA renewal.
-    with open(TLS_CA_FILE, "r") as ca_file:
-        old_ca_certificate = ca_file.read()
+    # The material the `rotated_ca` fixture downloaded after its rotation is still the current one
+    # and predates the provider-side CA renewal its short CA validity scheduled.
+    old_ca_certificate = rotated_ca.new_ca
     assert old_ca_certificate, "Failed to get current ca certificate"
-    with open(TLS_CERT_FILE, "r") as cert_file:
-        old_certificate = cert_file.read()
+    old_certificate = rotated_ca.new_certificate
     assert old_certificate, "Failed to get current certificate"
 
     logger.info("Check access with current TLS certificate")
@@ -303,7 +324,7 @@ def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     ), "Failed to read data with TLS enabled"
 
     logger.info("Waiting for CA certificate to expire")
-    sleep(max(0.0, _ca_rotation_config_time + CA_EXPIRY_TIME - monotonic()))
+    sleep(max(0.0, rotated_ca.config_time + CA_EXPIRY_TIME - monotonic()))
     # The units pick the renewed CA up at their next certificate renewal, then rotate: poll for
     # the old material being rejected rather than guessing how long that takes.
     for attempt in Retrying(

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -318,43 +318,48 @@ def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
                 password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
                 tls_enabled=True,
             ), "Client certificate of the previous CA is still accepted"
+    # The rotation is still rolling through the units at this point: keep re-downloading the
+    # material until it is the new CA's and the cluster accepts it.
+    for attempt in Retrying(
+        stop=stop_after_delay(DEPLOY_TIMEOUT_TLS_S), wait=wait_fixed(15), reraise=True
+    ):
+        with attempt:
+            logger.info("Store new certificate after rotation")
+            download_client_certificate_from_unit(juju, APP_NAME)
+            with open(TLS_CA_FILE, "r") as ca_file:
+                new_ca_certificate = ca_file.read()
+            assert new_ca_certificate, "Failed to get updated ca certificate"
+            with open(TLS_CERT_FILE, "r") as cert_file:
+                new_certificate = cert_file.read()
+            assert new_certificate, "Failed to get updated certificate"
+            assert old_ca_certificate != new_ca_certificate, "CA certificate was not updated"
+            assert old_certificate != new_certificate, "Certificate was not updated"
+
+            logger.info("Check access with updated certificate")
+            result = set_key(
+                juju=juju,
+                endpoints=endpoints,
+                username=CharmUsers.VALKEY_ADMIN.value,
+                password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
+                tls_enabled=True,
+                key=TEST_KEY,
+                value=TEST_VALUE,
+            )
+            assert result == "OK", "Failed to write data with updated certificate"
+
+            assert (
+                get_key(
+                    juju=juju,
+                    endpoints=endpoints,
+                    username=CharmUsers.VALKEY_ADMIN.value,
+                    password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
+                    tls_enabled=True,
+                    key=TEST_KEY,
+                )
+                == TEST_VALUE
+            ), "Failed to read data with updated certificate"
+
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=10, unit_count=NUM_UNITS),
         timeout=DEPLOY_TIMEOUT_TLS_S,
     )
-
-    logger.info("Store new certificate after rotation")
-    download_client_certificate_from_unit(juju, APP_NAME)
-    with open(TLS_CA_FILE, "r") as ca_file:
-        new_ca_certificate = ca_file.read()
-    assert new_ca_certificate, "Failed to get updated ca certificate"
-    with open(TLS_CERT_FILE, "r") as cert_file:
-        new_certificate = cert_file.read()
-    assert new_certificate, "Failed to get updated certificate"
-    assert old_ca_certificate != new_ca_certificate, "CA certificate was not updated"
-    assert old_certificate != new_certificate, "Certificate was not updated"
-
-    logger.info("Check access with updated certificate")
-    endpoints = get_cluster_endpoints(juju, APP_NAME)
-    result = set_key(
-        juju=juju,
-        endpoints=endpoints,
-        username=CharmUsers.VALKEY_ADMIN.value,
-        password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
-        tls_enabled=True,
-        key=TEST_KEY,
-        value=TEST_VALUE,
-    )
-    assert result == "OK", "Failed to write data with updated certificate"
-
-    assert (
-        get_key(
-            juju=juju,
-            endpoints=endpoints,
-            username=CharmUsers.VALKEY_ADMIN.value,
-            password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
-            tls_enabled=True,
-            key=TEST_KEY,
-        )
-        == TEST_VALUE
-    ), "Failed to read data with updated certificate"

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -2,9 +2,10 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 import logging
-from time import sleep
+from time import monotonic, sleep
 
 import jubilant
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from literals import CharmUsers, Substrate
 from statuses import TLSStatuses
@@ -34,7 +35,13 @@ NUM_UNITS = 3
 TEST_KEY = "test_key"
 TEST_VALUE = "test_value"
 CERTIFICATE_EXPIRY_TIME = 600
-CA_EXPIRY_TIME = 720
+# The provider renews a CA `certificate-validity` before it expires, i.e. 15 min after the CA
+# rotation test configures a 25 min CA with 10 min certificates, and the units pick the new CA up
+# at their next certificate renewal (every 0.6 x 10 min = 6 min): +18 min after that config,
+# safely after test_ca_rotation_by_config_change finished (its waits are bounded to +15 min) and
+# 3 min clear of the neighbouring renewals either side of the CA renewal.
+CA_EXPIRY_TIME = 1080
+_ca_rotation_config_time = 0.0
 
 
 def _prepare_units_for_ca_expiration_test(juju: jubilant.Juju, substrate: Substrate) -> None:
@@ -127,16 +134,20 @@ def test_certificate_expiration(juju: jubilant.Juju, substrate: Substrate) -> No
     assert old_client_certificate, "Failed to get current client certificate"
 
     logger.info("Waiting for certificate to expire")
-    sleep(CERTIFICATE_EXPIRY_TIME)
-
-    logger.info("Check access with previous certificate fails after expiration")
-    assert not auth_test(
-        juju=juju,
-        endpoints=endpoints,
-        username=CharmUsers.VALKEY_ADMIN.value,
-        password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
-        tls_enabled=True,
-    )
+    # Part of the validity already elapsed while TLS was being enabled: poll for the expiry
+    # instead of sleeping through the whole of it.
+    for attempt in Retrying(
+        stop=stop_after_delay(CERTIFICATE_EXPIRY_TIME), wait=wait_fixed(15), reraise=True
+    ):
+        with attempt:
+            logger.info("Check access with previous certificate fails after expiration")
+            assert not auth_test(
+                juju=juju,
+                endpoints=endpoints,
+                username=CharmUsers.VALKEY_ADMIN.value,
+                password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
+                tls_enabled=True,
+            ), "Expired certificate is still accepted"
 
     logger.info("Store new certificate after rotation")
     download_client_certificate_from_unit(juju, APP_NAME)
@@ -199,11 +210,19 @@ def test_ca_rotation_by_config_change(juju: jubilant.Juju) -> None:
     assert old_certificate, "Failed to get current certificate"
 
     logger.info("Rotating the CA certificate")
-    tls_config = {"certificate-validity": "10d", "ca-common-name": "new-valkey-ca"}
+    # The short CA validity schedules the provider-side CA renewal test_ca_rotation_by_expiration
+    # waits for, so that test does not need to rotate the CA a second time first.
+    tls_config = {
+        "certificate-validity": "10m",
+        "root-ca-validity": "25m",
+        "ca-common-name": "new-valkey-ca",
+    }
+    global _ca_rotation_config_time
+    _ca_rotation_config_time = monotonic()
     juju.config(app=TLS_NAME, values=tls_config)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Checking if the CA certificates are rotated")
@@ -249,23 +268,8 @@ def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     The CA certificate should be rotated and the cluster should still be accessible.
     The rotation is triggered by the expiration of the CA cert on TLS provider side.
     """
-    logger.info("Adjust CA and certificate validity on TLS provider")
-    tls_config = {"certificate-validity": "10m", "root-ca-validity": "20m"}
-    juju.config(app=TLS_NAME, values=tls_config)
-    juju.wait(
-        lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=900,
-    )
-    juju.wait(
-        lambda status: does_status_match(
-            status,
-            expected_unit_statuses={APP_NAME: [TLSStatuses.CERTIFICATE_EXPIRING.value]},
-            num_units={APP_NAME: NUM_UNITS},
-        ),
-        timeout=600,
-    )
-
-    download_client_certificate_from_unit(juju, APP_NAME)
+    # The CA and certificate validity were configured by test_ca_rotation_by_config_change; the
+    # material it downloaded last is still the current one and predates the CA renewal.
     with open(TLS_CA_FILE, "r") as ca_file:
         old_ca_certificate = ca_file.read()
     assert old_ca_certificate, "Failed to get current ca certificate"
@@ -299,20 +303,26 @@ def test_ca_rotation_by_expiration(juju: jubilant.Juju) -> None:
     ), "Failed to read data with TLS enabled"
 
     logger.info("Waiting for CA certificate to expire")
-    sleep(CA_EXPIRY_TIME)
+    sleep(max(0.0, _ca_rotation_config_time + CA_EXPIRY_TIME - monotonic()))
+    # The units pick the renewed CA up at their next certificate renewal, then rotate: poll for
+    # the old material being rejected rather than guessing how long that takes.
+    for attempt in Retrying(
+        stop=stop_after_delay(CERTIFICATE_EXPIRY_TIME), wait=wait_fixed(15), reraise=True
+    ):
+        with attempt:
+            logger.info("Check access with previous certificate fails after expiration")
+            assert not auth_test(
+                juju=juju,
+                endpoints=endpoints,
+                username=CharmUsers.VALKEY_ADMIN.value,
+                password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
+                tls_enabled=True,
+            ), "Client certificate of the previous CA is still accepted"
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=10, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
-    logger.info("Check access with previous certificate fails after expiration")
-    assert not auth_test(
-        juju=juju,
-        endpoints=endpoints,
-        username=CharmUsers.VALKEY_ADMIN.value,
-        password=get_password(juju, user=CharmUsers.VALKEY_ADMIN),
-        tls_enabled=True,
-    )
     logger.info("Store new certificate after rotation")
     download_client_certificate_from_unit(juju, APP_NAME)
     with open(TLS_CA_FILE, "r") as ca_file:

--- a/tests/integration/tls/test_certificate_rotation.py
+++ b/tests/integration/tls/test_certificate_rotation.py
@@ -10,6 +10,8 @@ from literals import CharmUsers, Substrate
 from statuses import TLSStatuses
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_S,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CA_FILE,
@@ -74,7 +76,7 @@ def test_build_and_deploy(
                 GLIDE_RUNNER_NAME: 1,
             },
         ),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_S,
     )
 
 
@@ -84,9 +86,11 @@ def test_certificate_expiration(juju: jubilant.Juju, substrate: Substrate) -> No
 
     logger.info("Enabling TLS")
     juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
+    # The renewal_relative_time=0.6 patch above makes the first renewal (and its rolling
+    # sentinel restart) land ~6 min in, inside this wait — it needs the TLS budget.
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Downloading TLS certificate from deployed app.")

--- a/tests/integration/tls/test_private_key.py
+++ b/tests/integration/tls/test_private_key.py
@@ -10,6 +10,7 @@ from literals import TLS_CLIENT_PRIVATE_KEY_CONFIG, CharmUsers, Substrate
 from statuses import TLSStatuses
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CERT_FILE,
@@ -102,7 +103,7 @@ def test_valid_private_key(juju: jubilant.Juju) -> None:
     juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Downloading TLS certificate from deployed app.")

--- a/tests/integration/tls/test_private_key.py
+++ b/tests/integration/tls/test_private_key.py
@@ -5,6 +5,7 @@ import logging
 
 import jubilant
 from charmlibs.interfaces.tls_certificates import PrivateKey
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from literals import TLS_CLIENT_PRIVATE_KEY_CONFIG, CharmUsers, Substrate
 from statuses import TLSStatuses
@@ -156,9 +157,19 @@ def test_private_key_updated(juju: jubilant.Juju) -> None:
         identifier=TLS_CLIENT_PRIVATE_KEY_CONFIG,
         content={"private-key": new_private_key},
     )
+
+    # An idle wait alone races here: juju delivers secret-changed asynchronously, so the
+    # cluster still looks idle right after update-secret. Wait for the renewal to land first.
+    logger.info("Waiting for the new private key to be applied on the unit")
+    for attempt in Retrying(stop=stop_after_delay(600), wait=wait_fixed(10), reraise=True):
+        with attempt:
+            download_client_certificate_from_unit(juju, APP_NAME)
+            with open(TLS_KEY_FILE, "r") as key_file:
+                assert key_file.read() == new_private_key, "New private key not applied yet"
+
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Downloading TLS certificate from deployed app.")

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -8,6 +8,7 @@ import jubilant
 from literals import CharmUsers, Substrate
 from tests.integration.helpers import (
     APP_NAME,
+    DEPLOY_TIMEOUT_TLS_S,
     GLIDE_RUNNER_NAME,
     IMAGE_RESOURCE,
     TLS_CHANNEL,
@@ -53,7 +54,7 @@ def test_build_and_deploy(
                 GLIDE_RUNNER_NAME: 1,
             },
         ),
-        timeout=900,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
 
@@ -111,7 +112,7 @@ def test_disable_tls(juju: jubilant.Juju) -> None:
 
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS + 1),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     endpoints = get_cluster_endpoints(juju, APP_NAME)
@@ -146,7 +147,7 @@ def test_enable_tls(juju: jubilant.Juju) -> None:
     juju.integrate(f"{APP_NAME}:client-certificates", TLS_NAME)
     juju.wait(
         lambda status: are_agents_idle(status, APP_NAME, idle_period=30, unit_count=NUM_UNITS + 1),
-        timeout=600,
+        timeout=DEPLOY_TIMEOUT_TLS_S,
     )
 
     logger.info("Downloading TLS certificates from deployed app.")

--- a/tests/unit/test_ip_change_reconcile.py
+++ b/tests/unit/test_ip_change_reconcile.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Self-healing reconciliation of a VM unit's address change."""
+
+from contextlib import ExitStack
+from unittest.mock import PropertyMock, patch
+
+from ops import testing
+
+from common.custom_events import RefreshTLSCertificatesEvent
+from common.exceptions import ValkeyWorkloadCommandError
+from src.charm import ValkeyCharm
+from src.literals import CLIENT_TLS_RELATION_NAME, PEER_RELATION
+
+CONTAINER = "valkey"
+
+OLD_IP = "127.0.1.1"
+# must match the autouse `mock_bind_address` fixture in conftest.py
+NEW_IP = "127.1.1.1"
+
+
+def _peer_relation(private_ip: str = OLD_IP) -> testing.PeerRelation:
+    return testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"start-state": "started", "private-ip": private_ip},
+    )
+
+
+def _state(cloud_spec, *, relations: set, leader: bool = True) -> testing.State:
+    return testing.State(
+        leader=leader,
+        relations=relations,
+        containers={testing.Container(name=CONTAINER, can_connect=True)},
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+    )
+
+
+def _client_tls_relation() -> testing.Relation:
+    return testing.Relation(
+        id=2,
+        endpoint=CLIENT_TLS_RELATION_NAME,
+        interface="tls-certificates",
+        remote_app_name="self-signed-certificates",
+    )
+
+
+def _reconcile_env() -> ExitStack:
+    """Patch the workload/manager side effects the address reconcile performs."""
+    patches = (
+        patch("managers.config.ConfigManager.configure_services"),
+        patch("managers.auth.AuthManager.configure_auth"),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.1.2"),
+        patch("managers.sentinel.SentinelManager.restart_service"),
+        # stands in for `openssl x509 -ext subjectAltName`: the on-disk SANs carry OLD_IP
+        patch(
+            "workload_vm.ValkeyVmWorkload.exec",
+            return_value=(f"DNS:www.example.com, IP Address:{OLD_IP}",),
+        ),
+        patch("workload_vm.ValkeyVmWorkload.restart"),
+        patch("managers.tls.TLSManager.build_sans_ip", return_value=frozenset({NEW_IP})),
+        patch(
+            "managers.tls.TLSManager.build_sans_dns", return_value=frozenset({"www.example.com"})
+        ),
+        patch("managers.tls.TLSManager.will_certificate_expire", return_value=False),
+        patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
+        patch("managers.sentinel.SentinelManager.is_healthy", return_value=True),
+        patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write"),
+    )
+    stack = ExitStack()
+    for p in patches:
+        stack.enter_context(p)
+    return stack
+
+
+def test_update_status_refreshes_client_certificate_when_ip_changed(cloud_spec_vm):
+    """update-status must converge a unit whose IP changed while client TLS is enabled."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation(), _client_tls_relation()})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+
+    # with a provider related, the charm must request a new CSR, not self-sign
+    assert any(isinstance(e, RefreshTLSCertificatesEvent) for e in ctx.emitted_events), (
+        "update-status did not request a certificate refresh after the unit's IP changed"
+    )
+    mock_create_certificate.assert_not_called()
+
+
+def test_update_status_regenerates_self_signed_certificate_when_ip_changed(cloud_spec_vm):
+    """Without a client TLS provider the charm regenerates the self-signed cert itself."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation()})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+
+    mock_create_certificate.assert_called_once()
+    assert state_out.get_relation(1).local_unit_data["private-ip"] == NEW_IP
+
+
+def test_update_status_does_not_reconcile_when_ip_unchanged(cloud_spec_vm):
+    """A unit whose address is unchanged must not reconfigure or reissue certificates."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation(private_ip=NEW_IP)})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+        patch("managers.auth.AuthManager.configure_auth") as mock_configure_auth,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+
+    mock_create_certificate.assert_not_called()
+    mock_configure_auth.assert_not_called()
+    assert not any(isinstance(e, RefreshTLSCertificatesEvent) for e in ctx.emitted_events)
+
+
+def test_update_status_reconciles_on_non_leader_unit(cloud_spec_vm):
+    """Any unit can be the one whose address changed, so the reconcile precedes the leader check."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation()}, leader=False)
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+
+    mock_create_certificate.assert_called_once()
+    assert state_out.get_relation(1).local_unit_data["private-ip"] == NEW_IP
+
+
+def test_update_status_survives_certificate_read_failure(cloud_spec_vm):
+    """A failed cert read must not error the unit — update-status runs on every interval."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation()})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.get_current_sans",
+            side_effect=ValkeyWorkloadCommandError("cannot read certificate"),
+        ),
+    ):
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+
+    assert not state_out.deferred
+
+
+def test_config_changed_defers_on_certificate_read_failure(cloud_spec_vm):
+    """config-changed has no periodic retry, so it must defer instead of dropping the reconcile."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation()})
+
+    with (
+        _reconcile_env(),
+        patch("events.base_events.BaseEvents._update_internal_users_password"),
+        patch(
+            "managers.tls.TLSManager.get_current_sans",
+            side_effect=ValkeyWorkloadCommandError("cannot read certificate"),
+        ),
+    ):
+        state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert [d.name for d in state_out.deferred] == ["config_changed"]
+
+
+def test_update_status_does_not_defer_while_awaiting_provider_certificate(cloud_spec_vm):
+    """Waiting on the TLS provider must not build a deferral backlog on a periodic hook."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation(), _client_tls_relation()})
+
+    with _reconcile_env():
+        state_out = ctx.run(ctx.on.update_status(), state_in)
+
+    assert any(isinstance(e, RefreshTLSCertificatesEvent) for e in ctx.emitted_events)
+    assert not state_out.deferred
+
+
+def test_update_status_is_noop_on_k8s(cloud_spec):
+    """K8s uses hostnames, so the address reconcile must not even read the binding."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec, relations={_peer_relation()})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock,
+            side_effect=ValueError("no binding on k8s"),
+        ),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+
+    mock_create_certificate.assert_not_called()

--- a/tests/unit/test_ip_change_reconcile.py
+++ b/tests/unit/test_ip_change_reconcile.py
@@ -131,6 +131,30 @@ def test_update_status_does_not_reconcile_when_ip_unchanged(cloud_spec_vm):
     assert not any(isinstance(e, RefreshTLSCertificatesEvent) for e in ctx.emitted_events)
 
 
+def test_update_status_does_not_reconcile_before_an_address_is_recorded(cloud_spec_vm):
+    """A unit that has not recorded an address yet has nothing to reconcile.
+
+    `private-ip` is first written on start, so a config-changed/update-status arriving
+    before that must not be read as "the address changed" and drive a reconfigure and
+    restart of a unit that has not started.
+    """
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = _state(cloud_spec_vm, relations={_peer_relation(private_ip="")})
+
+    with (
+        _reconcile_env(),
+        patch(
+            "managers.tls.TLSManager.create_and_store_self_signed_certificate"
+        ) as mock_create_certificate,
+        patch("managers.auth.AuthManager.configure_auth") as mock_configure_auth,
+    ):
+        ctx.run(ctx.on.update_status(), state_in)
+
+    mock_create_certificate.assert_not_called()
+    mock_configure_auth.assert_not_called()
+    assert not any(isinstance(e, RefreshTLSCertificatesEvent) for e in ctx.emitted_events)
+
+
 def test_update_status_reconciles_on_non_leader_unit(cloud_spec_vm):
     """Any unit can be the one whose address changed, so the reconcile precedes the leader check."""
     ctx = testing.Context(ValkeyCharm, app_trusted=True)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1506,3 +1506,35 @@ def test_peer_relation_changed_ca_rotation_workload_error_defers(cloud_spec):
             ctx.on.relation_changed(relation=peer_relation, remote_unit=1), state_in
         )
     assert "valkey_peers_relation_changed" in [e.name for e in state_out.deferred]
+
+
+def test_certificate_already_applied_without_peer_relation(cloud_spec):
+    # A certificate-available can arrive before the peer relation exists, so the
+    # idempotency guard must degrade to "not applied" instead of dereferencing the
+    # unbuilt unit databag model.
+    ca = MagicMock("my_ca")
+    ca.raw = "my_ca"
+    csr = MagicMock("my_csr")
+    csr.raw = "my_csr"
+    cert = MagicMock("my_cert")
+    cert.raw = "my_cert"
+
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    client_tls_relation = testing.Relation(id=3, endpoint=CLIENT_TLS_RELATION_NAME)
+    certificate = ProviderCertificate(
+        relation_id=3, certificate=cert, certificate_signing_request=csr, ca=ca, chain=[cert, ca]
+    )
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        leader=True,
+        relations={status_peer_relation, client_tls_relation},
+        containers={container},
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+    )
+
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        charm: ValkeyCharm = manager.charm
+
+        assert charm.state.unit_server.model is None
+        assert charm.tls_manager.certificate_already_applied(certificate) is False

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -2,6 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from hashlib import sha256
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,7 @@ from charmlibs.interfaces.tls_certificates import (
 )
 from ops import testing
 
+from common.exceptions import ValkeyTLSLoadError
 from src.charm import ValkeyCharm
 from src.common.exceptions import ValkeyWorkloadCommandError
 from src.literals import (
@@ -304,8 +306,11 @@ def test_client_certificate_denied(cloud_spec):
 
 def test_client_certificate_available(cloud_spec):
     ca = MagicMock("my_ca")
+    ca.raw = "my_ca"
     csr = MagicMock("my_csr")
+    csr.raw = "my_csr"
     cert = MagicMock("my_cert")
+    cert.raw = "my_cert"
 
     ctx = testing.Context(ValkeyCharm, app_trusted=True)
     peer_relation = testing.PeerRelation(
@@ -564,6 +569,139 @@ def test_client_certificate_renewed(cloud_spec):
             assert write_certs.call_count == 3
             reload_tls.assert_called_once()
             assert state_out.get_relation(1).local_unit_data.get("client-cert-ready") == "true"
+            assert (
+                state_out.get_relation(1).local_unit_data.get("applied-client-cert-fingerprint")
+                == sha256(b"my_certmy_ca").hexdigest()
+            )
+
+
+def test_certificate_re_emitted_unchanged_skips_restart(cloud_spec):
+    # The tls lib re-emits certificate-available for an unchanged certificate on
+    # every relation-changed of the client-certificates relation (shared across
+    # units, so every peer's renewal fires it); an already-applied certificate
+    # must be a no-op, or Sentinel gets restarted on every re-emission.
+    ca = MagicMock("my_ca")
+    ca.raw = "my_ca"
+    csr = MagicMock("my_csr")
+    csr.raw = "my_csr"
+    cert = MagicMock("my_cert")
+    cert.raw = "my_cert"
+    private_key = MagicMock("my_key")
+    private_key.raw = "my_key"
+
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={
+            "start-state": "started",
+            "tls-client-state": "tls",
+            "client-cert-ready": "true",
+            "applied-client-cert-fingerprint": sha256(b"my_certmy_ca").hexdigest(),
+        },
+    )
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    client_tls_relation = testing.Relation(id=3, endpoint=CLIENT_TLS_RELATION_NAME)
+    certificate = ProviderCertificate(
+        relation_id=3, certificate=cert, certificate_signing_request=csr, ca=ca, chain=[cert, ca]
+    )
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        leader=True,
+        relations={peer_relation, status_peer_relation, client_tls_relation},
+        containers={container},
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+    )
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        charm: ValkeyCharm = manager.charm
+        event = MagicMock(spec=CertificateAvailableEvent)
+
+        with (
+            patch(
+                "charmlibs.interfaces.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                return_value=([certificate], private_key),
+            ),
+            patch("charmlibs.pathops.ContainerPath.mkdir"),
+            patch("charmlibs.pathops.ContainerPath.exists", return_value=True),
+            patch("charmlibs.pathops.ContainerPath.read_text", return_value="my_ca"),
+            patch("workload_k8s.ValkeyK8sWorkload.write_file") as write_certs,
+            patch("managers.tls.TLSManager.rehash_ca_certificates") as rehash,
+            patch("managers.cluster.ClusterManager.reload_tls_settings") as reload_tls,
+            patch("workload_k8s.ValkeyK8sWorkload.restart") as restart,
+        ):
+            event.certificate = certificate.certificate
+            charm.tls_events._on_certificate_available(event)
+            manager.run()
+
+            write_certs.assert_not_called()
+            rehash.assert_not_called()
+            reload_tls.assert_not_called()
+            restart.assert_not_called()
+            event.defer.assert_not_called()
+
+
+def test_failed_tls_reload_does_not_record_fingerprint(cloud_spec):
+    # A deferred apply must stay retryable: the fingerprint is only recorded
+    # once reload+restart has been handed off, so a redelivered event after a
+    # failed reload still does the work instead of being skipped.
+    ca = MagicMock("my_ca")
+    ca.raw = "my_ca"
+    csr = MagicMock("my_csr")
+    csr.raw = "my_csr"
+    cert = MagicMock("my_cert")
+    cert.raw = "my_cert"
+    private_key = MagicMock("my_key")
+    private_key.raw = "my_key"
+
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    peer_relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={"start-state": "started", "tls-client-state": "tls"},
+    )
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    client_tls_relation = testing.Relation(id=3, endpoint=CLIENT_TLS_RELATION_NAME)
+    certificate = ProviderCertificate(
+        relation_id=3, certificate=cert, certificate_signing_request=csr, ca=ca, chain=[cert, ca]
+    )
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        leader=True,
+        relations={peer_relation, status_peer_relation, client_tls_relation},
+        containers={container},
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+    )
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        charm: ValkeyCharm = manager.charm
+        event = MagicMock(spec=CertificateAvailableEvent)
+
+        with (
+            patch(
+                "charmlibs.interfaces.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+                return_value=([certificate], private_key),
+            ),
+            patch("charmlibs.pathops.ContainerPath.mkdir"),
+            patch("charmlibs.pathops.ContainerPath.exists", return_value=True),
+            patch("charmlibs.pathops.ContainerPath.read_text", return_value="my_ca"),
+            patch("charmlibs.pathops.ContainerPath.write_text"),
+            patch("workload_k8s.ValkeyK8sWorkload.write_file"),
+            patch("managers.tls.TLSManager.rehash_ca_certificates"),
+            patch(
+                "managers.cluster.ClusterManager.reload_tls_settings",
+                side_effect=ValkeyTLSLoadError("reload failed"),
+            ),
+            patch("managers.sentinel.SentinelManager.get_primary_ip"),
+            patch("workload_k8s.ValkeyK8sWorkload.restart"),
+        ):
+            event.certificate = certificate.certificate
+            charm.tls_events._on_certificate_available(event)
+            state_out = manager.run()
+
+            event.defer.assert_called_once()
+            assert (
+                state_out.get_relation(1).local_unit_data.get("applied-client-cert-fingerprint")
+                is None
+            )
 
 
 def test_new_client_ca_single_unit(cloud_spec):


### PR DESCRIPTION
Root-causes and fixes the recurring integration flakes. One charm fix; everything else is test/CI.

### Charm
- **VM**: a unit that changed IP kept serving a certificate with stale SANs — `config-changed`
  can run while Juju's binding still reports the old address, and nothing retried afterwards.
  The reconcile now also runs from `update-status`, so a missed window self-heals. Unit tests added.
- **TLS**: the tls-certificates lib re-emits `certificate_available` even when the
  certificate is unchanged, and the relation is app-shared — so any unit's renewal
  restarted Sentinel on *every* unit. That RestartLock churn is what kept
  `k8s/test_certificate_rotation` from ever settling (the original flaky-TLS failure).
  The handler now skips already-applied certificates: a fingerprint in the unit databag,
  recorded only after the restart is handed off, so a failed apply is still retried.
  Restarting on a real change stays. Unit tests added.
  
### Tests
- The `no_ip_change` network cut now actually cuts (iptables drop). The old 1 kbit throttle let
  Sentinel heartbeats trickle through, so `+odown` quorum never formed and no failover was ever
  attempted — the cause of the recurring `test_network_cut_primary[no_ip_change-*]` failures.
- `test_failover_topology_update` polls for real failover convergence: `sentinel failover`
  returns on initiation, so the agents-idle wait passed instantly and writes hit the demoting primary.
- Waits spanning a client-TLS enable widened to 900s (the rolling sentinel restart behind it
  takes ~6–9 min for 3 units); other waits stay at 600s.
- `juju ssh` timeout in the signal helper sized for the connection (60s), not the instant pkill.

### CI
- Bootstrap Canonical K8s with pod CIDR `10.42.0.0/16`: the default `10.1.0.0/16` collides with
  the GitHub runner's own subnet, so a pod handed the gateway address could not reach the apiserver.
- Capture valkey/sentinel server log files as artifacts (they log to files, not stdout — this is
  what made the network-cut root cause visible).
- Retry the setup network fetches (snap store, uv installer) that killed runs before any test ran.