### PR TITLE
[DPE-10650] S3 restore followup

### DIFF
--- a/src/core/cluster_state.py
+++ b/src/core/cluster_state.py
@@ -266,12 +266,12 @@ class ClusterState(ops.Object, StatusesStateProtocol):
         """
         token = self.cluster.restore_token
         participants = set(self.cluster.restore_participants)
+        # restore_failure_kind is "" for a participant that didn't fail this attempt.
         kinds = {
-            server.restore_failure_kind(token)
+            kind
             for server in self.servers
-            if server.unit_name in participants
+            if server.unit_name in participants and (kind := server.restore_failure_kind(token))
         }
-        kinds.discard("")
         if RestoreFailure.UNHEALTHY.value in kinds:
             return RestoreFailure.UNHEALTHY.value
         return RestoreFailure.FAILED.value if kinds else ""

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -86,7 +86,6 @@ class BackupEvents(ops.Object):
             self.charm.on[PEER_RELATION].relation_departed, self._on_restore_workflow
         )
         self.framework.observe(self.charm.on.update_status, self._on_restore_workflow)
-        self.framework.observe(self.charm.on.update_status, self._reconcile_failover_suppression)
 
     # ── event handlers ──────────────────────────────────────────────────
 
@@ -335,9 +334,13 @@ class BackupEvents(ops.Object):
         Juju's one self-delivery guarantee. No in-hook loop; every guard below is
         idempotent, so a redelivered hook re-runs and converges.
         """
-        # Restore done: each unit clears its own per-unit state once restore_id is gone.
+        # Restore done: each unit clears its own per-unit state once restore_id is gone,
+        # and self-heals a sentinel a failed restore left failover-suppressed --
+        # suppression is only legitimate while a restore runs.
         if not self.charm.state.cluster.is_restore_in_progress:
             self._clear_local_restore_state()
+            if self.charm.state.unit_server.is_active:
+                self.charm.sentinel_manager.reconcile_failover_suppression()
             return
 
         # Leader ends a failed restore on a participant failure or departure
@@ -378,19 +381,6 @@ class BackupEvents(ops.Object):
 
         if self.charm.unit.is_leader():
             self._advance_if_leader()
-
-    def _reconcile_failover_suppression(self, _: ops.UpdateStatusEvent) -> None:
-        """Self-heal this unit's sentinel if a failed restore left failover suppressed.
-
-        Suppression is only legitimate while a restore runs, so this unit's
-        sentinel is re-checked on every update-status outside one.
-        """
-        if (
-            not self.charm.state.unit_server.is_active
-            or self.charm.state.cluster.is_restore_in_progress
-        ):
-            return
-        self.charm.sentinel_manager.reconcile_failover_suppression()
 
     def _clear_local_restore_state(self) -> None:
         """Clear this unit's per-unit restore fields once a restore has ended."""

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -165,9 +165,8 @@ class BackupEvents(ops.Object):
             return
         # Audit log: tie this action invocation to the backup it produces.
         logger.info(
-            "audit: create-backup action invoked action_id=%s unit=%s",
+            "audit: create-backup action invoked action_id=%s",
             event.id,
-            self.charm.unit.name,
         )
         event.log("Streaming backup to S3 ...")
         # Surface the running backup in juju status; is_action beats lower-priority statuses.
@@ -204,9 +203,8 @@ class BackupEvents(ops.Object):
             event.fail(reason)
             return
         logger.info(
-            "audit: list-backups action invoked action_id=%s unit=%s",
+            "audit: list-backups action invoked action_id=%s",
             event.id,
-            self.charm.unit.name,
         )
         try:
             ids = self.charm.backup_manager.list_backups()
@@ -293,14 +291,17 @@ class BackupEvents(ops.Object):
         """Validate, then initiate the async restore workflow (leader only)."""
         backup_id = event.params.get("backup-id", "")
         if reason := self._restore_blocking_reason(backup_id):
-            self._reject_restore(event, backup_id, reason)
+            logger.warning(
+                "restore.rejected backup_id=%s reason=%s", backup_id or "<none>", reason
+            )
+            event.set_results({"error": reason})
+            event.fail(reason)
             return
 
         logger.info(
-            "audit: restore action invoked action_id=%s backup_id=%s unit=%s participants=%s",
+            "audit: restore action invoked action_id=%s backup_id=%s participants=%s",
             event.id,
             backup_id,
-            self.charm.unit.name,
             [s.unit_name for s in self.charm.state.servers],
         )
         # Clear any stale terminal status from a prior attempt.
@@ -318,13 +319,6 @@ class BackupEvents(ops.Object):
         )
         # the action is async, the actual restore procedure is triggered by relation-changed events
         event.set_results({"restore": f"initiated for {backup_id}"})
-
-    @staticmethod
-    def _reject_restore(event: ops.ActionEvent, backup_id: str, reason: str) -> None:
-        """Fail the restore action with ``reason`` and leave a traceable log line."""
-        logger.warning("restore.rejected backup_id=%s reason=%s", backup_id or "<none>", reason)
-        event.set_results({"error": reason})
-        event.fail(reason)
 
     # ── restore workflow ─────────────────────────────────────────────────
 
@@ -433,7 +427,6 @@ class BackupEvents(ops.Object):
                 if self.charm.backup_manager.has_pre_restore_copy() and not (
                     self.charm.workload.alive(self.charm.workload.valkey_service)
                 ):
-                    logger.warning("restore.step restore: interrupted mid-swap; rolling back")
                     self.charm.backup_manager.roll_back()
                     raise ValkeyRestoreError("primary restore interrupted mid-swap; rolled back")
 
@@ -446,35 +439,25 @@ class BackupEvents(ops.Object):
                     self.charm.state.cluster.restore_id,
                 )
                 if is_primary:
-                    logger.info("restore.step restore: suppressing sentinel failover")
                     self.charm.sentinel_manager.suppress_failover()
                     self._do_primary_restore()
-                self._record_restore_step(RestoreStep.RESTORE)
+                self.charm.backup_manager.set_restore_step(RestoreStep.RESTORE)
 
             case (RestoreStep.RESYNC, RestoreStep.RESTORE):
                 if role == "primary":
-                    logger.info("restore.step resync role=primary: resuming sentinel failover")
                     self.charm.sentinel_manager.resume_failover()
                 else:
-                    logger.info(
-                        "restore.step resync role=replica: waiting up to %ss for resync",
-                        RESTORE_RESYNC_TIMEOUT_S,
-                    )
                     self.charm.cluster_manager.wait_until_resynced(RESTORE_RESYNC_TIMEOUT_S)
-                self._record_restore_step(RestoreStep.RESYNC)
+                self.charm.backup_manager.set_restore_step(RestoreStep.RESYNC)
 
             case (RestoreStep.COMPLETED, RestoreStep.RESYNC):
                 if role == "primary":
                     self.charm.backup_manager.cleanup_restore_files()
-                self._record_restore_step(RestoreStep.COMPLETED)
+                self.charm.backup_manager.set_restore_step(RestoreStep.COMPLETED)
 
             case _:
                 # Not our turn: tuple doesn't match a valid transition.
                 return
-
-    def _record_restore_step(self, step: RestoreStep) -> None:
-        self.charm.backup_manager.set_restore_step(step)
-        logger.info("restore.step_done step=%s unit=%s", step.value, self.charm.unit.name)
 
     def _do_primary_restore(self) -> None:
         """Validate, restore in-place, and roll back on any failure.
@@ -490,14 +473,8 @@ class BackupEvents(ops.Object):
         self.charm.cluster_manager.save_dataset_before_shutdown()
         try:
             self.charm.backup_manager.restore_on_primary()
-            logger.info(
-                "restore.primary: waiting up to %ss for the dataset to load",
-                RESTORE_LOAD_TIMEOUT_S,
-            )
             self.charm.cluster_manager.wait_until_loaded(RESTORE_LOAD_TIMEOUT_S)
-            logger.info("restore.primary: dataset loaded")
         except Exception:
-            logger.warning("restore.primary: failed; rolling back to the pre-restore dataset")
             self.charm.backup_manager.roll_back()
             raise
         finally:
@@ -548,7 +525,7 @@ class BackupEvents(ops.Object):
         # Stamp with the attempt token so it can't be misread against a later restore.
         marker = f"{kind.value}:{self.charm.state.cluster.restore_token}"
         self.charm.state.unit_server.update({"restore_failed": marker})
-        logger.warning("restore.failed unit=%s kind=%s", self.charm.unit.name, kind.value)
+        logger.warning("restore.failed kind=%s", kind.value)
         if self.charm.unit.is_leader():
             # Already resumed failover just above; don't do it twice.
             self._finish_failed_restore(resume=False)

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -241,8 +241,8 @@ class BackupEvents(ops.Object):
             return "A restore is in progress; backups are paused."
         return None
 
-    def _restore_blocking_reason(self) -> str | None:
-        """Return why a restore cannot start, or None if it can."""
+    def _restore_blocking_reason(self, backup_id: str) -> str | None:
+        """Return why a restore of ``backup_id`` cannot start, or None if it can."""
         if not self.charm.unit.is_leader():
             return "Restore must be run on the leader unit."
         if not self.charm.state.s3_relation:
@@ -259,7 +259,22 @@ class BackupEvents(ops.Object):
         # Require a stable cluster: all active, a resolvable primary, no failover in flight.
         if not all(s.is_active for s in self.charm.state.servers):
             return "Not all units are active; wait for the cluster to settle."
-        return self._unstable_primary_reason()
+        if reason := self._unstable_primary_reason():
+            return reason
+        # Last, since it is the only gate that costs an S3 round-trip.
+        return self._unusable_backup_reason(backup_id)
+
+    def _unusable_backup_reason(self, backup_id: str) -> str | None:
+        """Return why ``backup_id`` can't be restored from, or None if it can."""
+        if not backup_id:
+            return "Must provide backup-id to restore."
+        try:
+            if backup_id not in self.charm.backup_manager.list_backups():
+                return f"backup-id {backup_id} not found."
+        except ValkeyBackupError as e:
+            logger.exception("restore.list_backups_failed backup_id=%s", backup_id)
+            return f"Could not list backups: {_safe_error(e)}"
+        return None
 
     def _unstable_primary_reason(self) -> str | None:
         """Return why the Sentinel-managed primary isn't restorable, or None if it is."""
@@ -277,20 +292,8 @@ class BackupEvents(ops.Object):
     def _on_restore_action(self, event: ops.ActionEvent) -> None:
         """Validate, then initiate the async restore workflow (leader only)."""
         backup_id = event.params.get("backup-id", "")
-        if reason := self._restore_blocking_reason():
+        if reason := self._restore_blocking_reason(backup_id):
             self._reject_restore(event, backup_id, reason)
-            return
-        if not backup_id:
-            self._reject_restore(event, backup_id, "Must provide backup-id to restore.")
-            return
-        try:
-            if backup_id not in self.charm.backup_manager.list_backups():
-                self._reject_restore(event, backup_id, f"backup-id {backup_id} not found.")
-                return
-        except ValkeyBackupError as e:
-            logger.exception("restore.rejected backup_id=%s: could not list backups", backup_id)
-            event.set_results({"error": _safe_error(e)})
-            event.fail("Could not list backups. Check juju debug-log.")
             return
 
         logger.info(

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -86,6 +86,7 @@ class BackupEvents(ops.Object):
             self.charm.on[PEER_RELATION].relation_departed, self._on_restore_workflow
         )
         self.framework.observe(self.charm.on.update_status, self._on_restore_workflow)
+        self.framework.observe(self.charm.on.update_status, self._reconcile_failover_suppression)
 
     # ── event handlers ──────────────────────────────────────────────────
 
@@ -371,6 +372,31 @@ class BackupEvents(ops.Object):
 
         if self.charm.unit.is_leader():
             self._advance_if_leader()
+
+    def _reconcile_failover_suppression(self, _: ops.UpdateStatusEvent) -> None:
+        """Self-heal this unit's sentinel if it was left failover-suppressed.
+
+        resume_failover is best-effort on every restore-failure path, and Sentinel
+        persists SENTINEL SET to its own conf (a restart won't clear it), so a
+        sentinel unreachable at that moment would otherwise stay at the suppressed
+        down-after -- no automatic failover -- until the next config re-render.
+        Every unit re-checks its own sentinel here; outside a restore the value
+        must be the configured one.
+        """
+        if (
+            not self.charm.state.unit_server.is_active
+            or self.charm.state.cluster.is_restore_in_progress
+        ):
+            return
+        try:
+            if self.charm.sentinel_manager.is_failover_suppressed():
+                logger.warning(
+                    "restore.suppression_leak: sentinel still failover-suppressed outside a "
+                    "restore; resuming failover on this unit"
+                )
+                self.charm.sentinel_manager.resume_local_failover()
+        except ValkeyWorkloadCommandError as e:
+            logger.warning("Could not check sentinel failover suppression: %s", e)
 
     def _clear_local_restore_state(self) -> None:
         """Clear this unit's per-unit restore fields once a restore has ended."""

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -383,29 +383,17 @@ class BackupEvents(ops.Object):
             self._advance_if_leader()
 
     def _reconcile_failover_suppression(self, _: ops.UpdateStatusEvent) -> None:
-        """Self-heal this unit's sentinel if it was left failover-suppressed.
+        """Self-heal this unit's sentinel if a failed restore left failover suppressed.
 
-        resume_failover is best-effort on every restore-failure path, and Sentinel
-        persists SENTINEL SET to its own conf (a restart won't clear it), so a
-        sentinel unreachable at that moment would otherwise stay at the suppressed
-        down-after -- no automatic failover -- until the next config re-render.
-        Every unit re-checks its own sentinel here; outside a restore the value
-        must be the configured one.
+        Suppression is only legitimate while a restore runs, so this unit's
+        sentinel is re-checked on every update-status outside one.
         """
         if (
             not self.charm.state.unit_server.is_active
             or self.charm.state.cluster.is_restore_in_progress
         ):
             return
-        try:
-            if self.charm.sentinel_manager.is_failover_suppressed():
-                logger.warning(
-                    "restore.suppression_leak: sentinel still failover-suppressed outside a "
-                    "restore; resuming failover on this unit"
-                )
-                self.charm.sentinel_manager.resume_local_failover()
-        except ValkeyWorkloadCommandError as e:
-            logger.warning("Could not check sentinel failover suppression: %s", e)
+        self.charm.sentinel_manager.reconcile_failover_suppression()
 
     def _clear_local_restore_state(self) -> None:
         """Clear this unit's per-unit restore fields once a restore has ended."""

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -276,29 +276,29 @@ class BackupEvents(ops.Object):
 
     def _on_restore_action(self, event: ops.ActionEvent) -> None:
         """Validate, then initiate the async restore workflow (leader only)."""
+        backup_id = event.params.get("backup-id", "")
         if reason := self._restore_blocking_reason():
-            event.set_results({"error": reason})
-            event.fail(reason)
+            self._reject_restore(event, backup_id, reason)
             return
-        if not (backup_id := event.params.get("backup-id", "")):
-            event.set_results({"error": "Must provide backup-id to restore."})
-            event.fail("Must provide backup-id to restore.")
+        if not backup_id:
+            self._reject_restore(event, backup_id, "Must provide backup-id to restore.")
             return
         try:
             if backup_id not in self.charm.backup_manager.list_backups():
-                event.fail(f"backup-id {backup_id} not found.")
+                self._reject_restore(event, backup_id, f"backup-id {backup_id} not found.")
                 return
         except ValkeyBackupError as e:
-            logger.exception("Could not list backups for restore")
+            logger.exception("restore.rejected backup_id=%s: could not list backups", backup_id)
             event.set_results({"error": _safe_error(e)})
             event.fail("Could not list backups. Check juju debug-log.")
             return
 
         logger.info(
-            "audit: restore action invoked action_id=%s backup_id=%s unit=%s",
+            "audit: restore action invoked action_id=%s backup_id=%s unit=%s participants=%s",
             event.id,
             backup_id,
             self.charm.unit.name,
+            [s.unit_name for s in self.charm.state.servers],
         )
         # Clear any stale terminal status from a prior attempt.
         self._clear_terminal_restore_statuses()
@@ -315,6 +315,13 @@ class BackupEvents(ops.Object):
         )
         # the action is async, the actual restore procedure is triggered by relation-changed events
         event.set_results({"restore": f"initiated for {backup_id}"})
+
+    @staticmethod
+    def _reject_restore(event: ops.ActionEvent, backup_id: str, reason: str) -> None:
+        """Fail the restore action with ``reason`` and leave a traceable log line."""
+        logger.warning("restore.rejected backup_id=%s reason=%s", backup_id or "<none>", reason)
+        event.set_results({"error": reason})
+        event.fail(reason)
 
     # ── restore workflow ─────────────────────────────────────────────────
 
@@ -336,13 +343,13 @@ class BackupEvents(ops.Object):
             self._clear_local_restore_state()
             return
 
-        # Leader tears the restore down on a participant failure or departure
+        # Leader ends a failed restore on a participant failure or departure
         # (only it can clear the app-level restore_id).
-        if self._leader_restore_teardown_needed():
-            self._clear_failed_restore()
+        if self._leader_must_fail_restore():
+            self._finish_failed_restore()
             return
         # A unit that joined after initiation isn't a participant and must run no
-        # step (it would query its own down Valkey and spuriously tear down).
+        # step (it would query its own down Valkey and spuriously fail the restore).
         if self.charm.unit.name not in self.charm.state.cluster.restore_participants:
             # ...but a non-participant leader must still advance the barrier
             # (leadership can drift to a late-joiner), or nobody does -> wedge.
@@ -350,7 +357,7 @@ class BackupEvents(ops.Object):
                 self._advance_if_leader()
             return
         # This unit already failed this attempt (token-scoped, so a stale marker
-        # won't block a new one): wait for the leader to tear down.
+        # won't block a new one): wait for the leader to end the restore.
         if self.charm.state.unit_server.restore_failure_kind(
             self.charm.state.cluster.restore_token
         ):
@@ -363,11 +370,13 @@ class BackupEvents(ops.Object):
         try:
             self._run_restore_step(instruction, step, role)
         except Exception as e:
-            # Catch everything: teardown must record the failure marker and
-            # resume failover on ANY error (service-control errors sit outside
-            # the restore-error hierarchy), or the restore wedges.
-            logger.exception("Restore step failed; tearing down")
-            self._restore_teardown(e)
+            # Catch everything: the failure marker must be recorded and failover
+            # resumed on ANY error (service-control errors sit outside the
+            # restore-error hierarchy), or the restore wedges.
+            logger.exception(
+                "restore.step_failed instruction=%s step=%s role=%s", instruction, step, role
+            )
+            self._fail_restore(e)
             return
 
         if self.charm.unit.is_leader():
@@ -404,18 +413,19 @@ class BackupEvents(ops.Object):
         if unit.restore_step != RestoreStep.NOT_STARTED or unit.restore_failed:
             unit.update({"restore_step": "", "restore_role": "", "restore_failed": ""})
 
-    def _leader_restore_teardown_needed(self) -> bool:
-        """Whether the leader must tear the restore down now.
+    def _leader_must_fail_restore(self) -> bool:
+        """Whether the leader must end the restore as failed now.
 
         True on a participant failure this attempt, or a departed participant (which
         can never satisfy the barrier, so the restore would otherwise wedge).
         """
         if not self.charm.unit.is_leader():
             return False
-        if self.charm.state.failed_restore_kind:
+        if kind := self.charm.state.failed_restore_kind:
+            logger.warning("restore.participant_failed kind=%s; ending the restore", kind)
             return True
         if self.charm.state.restore_participant_departed:
-            logger.warning("Restore participant departed mid-restore; failing the restore")
+            logger.warning("restore.participant_departed; ending the restore")
             return True
         return False
 
@@ -432,40 +442,55 @@ class BackupEvents(ops.Object):
                 if self.charm.backup_manager.has_pre_restore_copy() and not (
                     self.charm.workload.alive(self.charm.workload.valkey_service)
                 ):
+                    logger.warning("restore.step restore: interrupted mid-swap; rolling back")
                     self.charm.backup_manager.roll_back()
                     raise ValkeyRestoreError("primary restore interrupted mid-swap; rolled back")
 
                 is_primary = self.charm.cluster_manager.is_primary()
-                self.charm.state.unit_server.update(
-                    {"restore_role": "primary" if is_primary else "replica"}
+                role = "primary" if is_primary else "replica"
+                self.charm.state.unit_server.update({"restore_role": role})
+                logger.info(
+                    "restore.step restore role=%s backup_id=%s",
+                    role,
+                    self.charm.state.cluster.restore_id,
                 )
                 if is_primary:
+                    logger.info("restore.step restore: suppressing sentinel failover")
                     self.charm.sentinel_manager.suppress_failover()
                     self._do_primary_restore()
-                self.charm.backup_manager.set_restore_step(RestoreStep.RESTORE)
+                self._record_restore_step(RestoreStep.RESTORE)
 
             case (RestoreStep.RESYNC, RestoreStep.RESTORE):
                 if role == "primary":
+                    logger.info("restore.step resync role=primary: resuming sentinel failover")
                     self.charm.sentinel_manager.resume_failover()
                 else:
+                    logger.info(
+                        "restore.step resync role=replica: waiting up to %ss for resync",
+                        RESTORE_RESYNC_TIMEOUT_S,
+                    )
                     self.charm.cluster_manager.wait_until_resynced(RESTORE_RESYNC_TIMEOUT_S)
-                self.charm.backup_manager.set_restore_step(RestoreStep.RESYNC)
+                self._record_restore_step(RestoreStep.RESYNC)
 
             case (RestoreStep.COMPLETED, RestoreStep.RESYNC):
                 if role == "primary":
                     self.charm.backup_manager.cleanup_restore_files()
-                self.charm.backup_manager.set_restore_step(RestoreStep.COMPLETED)
+                self._record_restore_step(RestoreStep.COMPLETED)
 
             case _:
                 # Not our turn: tuple doesn't match a valid transition.
                 return
+
+    def _record_restore_step(self, step: RestoreStep) -> None:
+        self.charm.backup_manager.set_restore_step(step)
+        logger.info("restore.step_done step=%s unit=%s", step.value, self.charm.unit.name)
 
     def _do_primary_restore(self) -> None:
         """Validate, restore in-place, and roll back on any failure.
 
         restore_on_primary does stop -> move dump aside -> download -> restart;
         the caller then confirms it loaded. Any failure rolls back to the
-        pre-restore copy before propagating to teardown.
+        pre-restore copy before propagating to _fail_restore.
         """
         # Pre-stop (outside the try, nothing to roll back yet): reject a non-RDB
         # object before bouncing the primary, and persist memory to disk so the
@@ -474,15 +499,22 @@ class BackupEvents(ops.Object):
         self.charm.cluster_manager.save_dataset_before_shutdown()
         try:
             self.charm.backup_manager.restore_on_primary()
+            logger.info(
+                "restore.primary: waiting up to %ss for the dataset to load",
+                RESTORE_LOAD_TIMEOUT_S,
+            )
             self.charm.cluster_manager.wait_until_loaded(RESTORE_LOAD_TIMEOUT_S)
+            logger.info("restore.primary: dataset loaded")
         except Exception:
+            logger.warning("restore.primary: failed; rolling back to the pre-restore dataset")
             self.charm.backup_manager.roll_back()
             raise
         finally:
-            # A restart (restore or rollback) resets runtime min-replicas-to-write
-            # to the rendered 1, so reassert the topology-correct value or a small
-            # cluster is write-frozen. Best-effort: a raise in a finally must not
-            # mask the failure or false-fail a success.
+            # valkey.conf ships min-replicas-to-write 1 and the topology-aware
+            # value (0 below 3 active units) is a non-persistent CONFIG SET, so any
+            # restart here (restore or rollback) comes back at 1 -- reassert it or a
+            # 1-2 unit cluster is write-frozen. Best-effort: a raise in a finally
+            # must not mask the failure or false-fail a success.
             try:
                 self.charm.cluster_manager.reconcile_min_replicas_to_write()
             except Exception:
@@ -494,26 +526,29 @@ class BackupEvents(ops.Object):
             return
         instruction = self.charm.state.cluster.restore_instruction
         if instruction == RestoreStep.COMPLETED:
+            logger.info("restore.completed backup_id=%s", self.charm.state.cluster.restore_id)
             self._clear_terminal_restore_statuses()
             self._clear_restore_state()
             return
-        self.charm.state.cluster.update(
-            {"restore_instruction": self.charm.backup_manager.next_restore_step(instruction).value}
+        next_step = self.charm.backup_manager.next_restore_step(instruction)
+        logger.info(
+            "restore.advance %s -> %s (all participants caught up)", instruction, next_step
         )
+        self.charm.state.cluster.update({"restore_instruction": next_step.value})
 
-    def _restore_teardown(self, exc: Exception | None = None) -> None:
-        """Record this unit's restore failure so the leader can tear it down.
+    def _fail_restore(self, exc: Exception | None = None) -> None:
+        """Mark this unit's restore attempt failed; the leader then ends the restore.
 
-        The failing unit is often not the juju leader, and only the leader can
-        clear the app-level restore_id, so the failure is recorded on this unit's
-        own databag; the leader acts on it via _clear_failed_restore (inline here
-        if this unit is the leader). resume_failover runs first but best-effort:
-        a raise must not stop the marker being recorded, or the restore re-wedges.
+        Resumes sentinel failover (best-effort: a raise must not stop the marker
+        being recorded, or the restore re-wedges) and records a failure marker on
+        this unit's own databag. The failing unit is often not the juju leader,
+        and only the leader can clear the app-level restore_id, so the leader
+        acts on the marker via _finish_failed_restore (inline if this unit is it).
         """
         try:
             self.charm.sentinel_manager.resume_failover()
         except Exception:
-            logger.exception("resume_failover during restore teardown failed")
+            logger.exception("resume_failover after a failed restore step raised")
         kind = (
             RestoreFailure.UNHEALTHY
             if isinstance(exc, ValkeyClusterNotReadyError)
@@ -522,16 +557,19 @@ class BackupEvents(ops.Object):
         # Stamp with the attempt token so it can't be misread against a later restore.
         marker = f"{kind.value}:{self.charm.state.cluster.restore_token}"
         self.charm.state.unit_server.update({"restore_failed": marker})
+        logger.warning("restore.failed unit=%s kind=%s", self.charm.unit.name, kind.value)
         if self.charm.unit.is_leader():
             # Already resumed failover just above; don't do it twice.
-            self._clear_failed_restore(resume=False)
+            self._finish_failed_restore(resume=False)
 
-    def _clear_failed_restore(self, resume: bool = True) -> None:
-        """Leader-only: flag the failure (UNHEALTHY vs FAILED) and clear restore state.
+    def _finish_failed_restore(self, resume: bool = True) -> None:
+        """Leader-only: end a failed restore and surface its terminal status.
 
-        ``resume`` resumes failover as a backstop, since a failing peer's own
-        best-effort resume may have raised. The leader-self teardown already
-        resumed, so it passes resume=False to avoid a redundant SENTINEL RESET.
+        Clears the app-level restore state (un-wedging the cluster) and adds
+        RESTORE_FAILED / RESTORE_UNHEALTHY. ``resume`` resumes failover as a
+        backstop, since a failing peer's own best-effort resume may have raised.
+        The leader-self path already resumed, so it passes resume=False to avoid
+        a redundant SENTINEL RESET.
         """
         # Read the failure kind while the token still matches the marker.
         status = (
@@ -539,17 +577,22 @@ class BackupEvents(ops.Object):
             if self.charm.state.failed_restore_kind == RestoreFailure.UNHEALTHY.value
             else RestoreStatuses.RESTORE_FAILED
         )
+        logger.warning(
+            "restore.ended backup_id=%s status=%s",
+            self.charm.state.cluster.restore_id,
+            status.name,
+        )
         # Clear restore state before the best-effort resume and status write.
         # This ordering isn't itself the wedge guard: if resume_failover raises
         # outside the narrow catch the hook errors and Juju rolls back this write
-        # too, so the leader just retries teardown until resume succeeds. Clearing
-        # first only keeps the intent (unwedge is the priority) explicit.
+        # too, so the leader just retries until resume succeeds. Clearing first
+        # only keeps the intent (unwedge is the priority) explicit.
         self._clear_restore_state()
         if resume:
             try:
                 self.charm.sentinel_manager.resume_failover()
             except ValkeyWorkloadCommandError:
-                logger.exception("resume_failover during leader restore teardown failed")
+                logger.exception("resume_failover while ending the failed restore raised")
         self.charm.state.statuses.add(
             status.value,
             scope="app",

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -382,6 +382,7 @@ class BackupManager(ManagerStatusProtocol):
     def set_restore_step(self, step: RestoreStep) -> None:
         """Record this unit's completed restore step on its databag."""
         self.state.unit_server.update({"restore_step": step.value})
+        logger.info("restore.step_done step=%s", step.value)
 
     def has_pre_restore_copy(self) -> bool:
         """Whether a rollback copy exists -- an interrupted primary restore.

--- a/src/managers/backup.py
+++ b/src/managers/backup.py
@@ -329,6 +329,7 @@ class BackupManager(ManagerStatusProtocol):
             raise ValkeyRestoreError(e) from e
         if not head.startswith(_RDB_MAGIC):
             raise ValkeyRestoreError(f"Object for {backup_id} is not a valid RDB stream")
+        logger.info("restore.verified backup_id=%s (RDB header ok)", backup_id)
 
     def download_backup(self, backup_id: str) -> None:
         """Stream the full RDB from S3 onto the data partition as ``dump.rdb``.
@@ -343,20 +344,27 @@ class BackupManager(ManagerStatusProtocol):
         bucket = self._get_bucket_resource(s3_parameters)
 
         try:
-            body = bucket.Object(f"{s3_parameters.path}/{backup_id}").get()["Body"]
+            obj = bucket.Object(f"{s3_parameters.path}/{backup_id}").get()
         except ClientError as e:
             raise ValkeyRestoreError(e) from e
 
+        logger.info(
+            "restore.download.started backup_id=%s bytes=%s -> %s",
+            backup_id,
+            obj.get("ContentLength"),
+            self._dump_tmp_path,
+        )
         # Stream S3 -> data partition; the StreamingBody is a binary read()-able
         # at runtime (cast for the stub), copied in bounded chunks by the workload.
         self.workload.push_data_file(
-            cast(BinaryIO, body),
+            cast(BinaryIO, obj["Body"]),
             self._dump_tmp_path,
             user=self.workload.user,
             group=self.workload.user,
         )
         # Atomic promote: same-partition rename, so dump.rdb only ever appears complete.
         self.workload.move_file(self._dump_tmp_path, self._dump_path)
+        logger.info("restore.download.finished backup_id=%s -> %s", backup_id, self._dump_path)
 
     # ── restore steps ────────────────────────────────────────────────────
 
@@ -403,16 +411,20 @@ class BackupManager(ManagerStatusProtocol):
         defer holds off concurrent restarts. Only runs for a fresh swap (redelivery
         is handled upstream), so any copy here is stale and dropped first.
         """
+        logger.info("restore.primary: stopping valkey-server for the RDB swap")
         self._ensure_stopped()
         if self.workload.path_exists(self._pre_restore_path):
             self.cleanup_restore_files()
+        logger.info("restore.primary: keeping the current dump at %s", self._pre_restore_path)
         self.workload.move_file(self._dump_path, self._pre_restore_path)
         self.download_backup(self.state.cluster.restore_id)
         # Readiness is gated later by wait_until_loaded.
+        logger.info("restore.primary: starting valkey-server on the restored dump")
         self.workload.start(self.workload.valkey_service, check_alive=False)
 
     def roll_back(self) -> None:
         """Restore the pre-restore dump and restart (stop FIRST to defeat auto-restart)."""
+        logger.warning("restore.rollback: reinstating the pre-restore dump and restarting")
         self._ensure_stopped()
         if self.workload.path_exists(self._pre_restore_path):
             self.workload.move_file(self._pre_restore_path, self._dump_path)
@@ -422,6 +434,7 @@ class BackupManager(ManagerStatusProtocol):
 
     def cleanup_restore_files(self) -> None:
         """Remove the pre-restore rollback copy after a successful restore."""
+        logger.info("restore.cleanup: removing the pre-restore copy %s", self._pre_restore_path)
         self.workload.remove_file(self._pre_restore_path)
 
     # ── helpers ─────────────────────────────────────────────────────────

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -5,6 +5,7 @@
 """Manager for all cluster related tasks."""
 
 import logging
+from collections.abc import Callable
 from time import sleep
 
 from data_platform_helpers.advanced_statuses.models import StatusObject
@@ -165,29 +166,21 @@ class ClusterManager(ManagerStatusProtocol):
             logger.error("Could not query replication offset")
             return
 
+    def is_loaded(self) -> bool:
+        """Whether the local server responds and has finished loading its dataset."""
+        client = self._get_valkey_client()
+        return (
+            client.ping(hostname=self.state.endpoint)
+            and client.info_persistence(hostname=self.state.endpoint).get("loading", "1") == "0"
+        )
+
     def wait_until_loaded(self, timeout_s: int) -> None:
         """Bounded poll until the server responds and has finished loading.
 
         Raises ValkeyClusterNotReadyError on timeout rather than hanging, so the
         caller can react (e.g. roll back a restore).
         """
-        client = self._get_valkey_client()
-        try:
-            for attempt in Retrying(
-                stop=stop_after_delay(timeout_s), wait=wait_fixed(5), reraise=True
-            ):
-                with attempt:
-                    if not client.ping(hostname=self.state.endpoint):
-                        raise ValkeyClusterNotReadyError("server not responding yet")
-                    if (
-                        client.info_persistence(hostname=self.state.endpoint).get("loading", "1")
-                        != "0"
-                    ):
-                        raise ValkeyClusterNotReadyError("still loading dataset")
-        except Exception as e:  # tenacity reraises the last attempt's error
-            raise ValkeyClusterNotReadyError(
-                f"Server did not become ready within {timeout_s}s"
-            ) from e
+        self._wait_until(self.is_loaded, timeout_s, "server did not become ready")
 
     def wait_until_resynced(self, timeout_s: int) -> None:
         """Bounded poll until this replica is in sync with the primary.
@@ -195,15 +188,23 @@ class ClusterManager(ManagerStatusProtocol):
         Unlike wait_for_replica_fully_synced (unbounded), raises
         ValkeyClusterNotReadyError on timeout so the caller can react.
         """
+        self._wait_until(self.is_replica_synced, timeout_s, "replica did not resync")
+
+    def _wait_until(self, condition: Callable[[], bool], timeout_s: int, failure: str) -> None:
+        """Poll ``condition`` every 5s for up to ``timeout_s``; raise NotReady on timeout.
+
+        A raising ``condition`` (e.g. the CLI can't connect yet) is retried like
+        a False one; the last error is chained onto the timeout exception.
+        """
         try:
             for attempt in Retrying(
                 stop=stop_after_delay(timeout_s), wait=wait_fixed(5), reraise=True
             ):
                 with attempt:
-                    if not self.is_replica_synced():
-                        raise ValkeyClusterNotReadyError("replica not yet synced")
-        except Exception as e:
-            raise ValkeyClusterNotReadyError(f"Replica did not resync within {timeout_s}s") from e
+                    if not condition():
+                        raise ValkeyClusterNotReadyError("condition not met yet")
+        except Exception as e:  # tenacity reraises the last attempt's error
+            raise ValkeyClusterNotReadyError(f"{failure} within {timeout_s}s") from e
 
     @retry(
         wait=wait_fixed(5),

--- a/src/managers/cluster.py
+++ b/src/managers/cluster.py
@@ -180,7 +180,9 @@ class ClusterManager(ManagerStatusProtocol):
         Raises ValkeyClusterNotReadyError on timeout rather than hanging, so the
         caller can react (e.g. roll back a restore).
         """
+        logger.info("restore.wait: dataset to load (up to %ss)", timeout_s)
         self._wait_until(self.is_loaded, timeout_s, "server did not become ready")
+        logger.info("restore.wait: dataset loaded")
 
     def wait_until_resynced(self, timeout_s: int) -> None:
         """Bounded poll until this replica is in sync with the primary.
@@ -188,7 +190,9 @@ class ClusterManager(ManagerStatusProtocol):
         Unlike wait_for_replica_fully_synced (unbounded), raises
         ValkeyClusterNotReadyError on timeout so the caller can react.
         """
+        logger.info("restore.wait: replica resync (up to %ss)", timeout_s)
         self._wait_until(self.is_replica_synced, timeout_s, "replica did not resync")
+        logger.info("restore.wait: replica resynced")
 
     def _wait_until(self, condition: Callable[[], bool], timeout_s: int, failure: str) -> None:
         """Poll ``condition`` every 5s for up to ``timeout_s``; raise NotReady on timeout.

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -412,6 +412,28 @@ class SentinelManager(ManagerStatusProtocol):
         down_after = client.primary(hostname=self.state.endpoint).get("down-after-milliseconds")
         return str(down_after) == str(SENTINEL_DOWN_AFTER_SUPPRESSED_MS)
 
+    def reconcile_failover_suppression(self) -> None:
+        """Reset this unit's sentinel if a restore left it failover-suppressed.
+
+        resume_failover is best-effort on every restore-failure path, and Sentinel
+        persists SENTINEL SET to its own conf (a restart won't clear it), so a
+        sentinel unreachable at that moment would otherwise stay at the suppressed
+        down-after -- no automatic failover -- until the next config re-render.
+        Callers invoke this outside a restore, where the value must be the
+        configured one. An unreachable sentinel is skipped, not an error: the next
+        call retries it.
+        """
+        try:
+            if not self.is_failover_suppressed():
+                return
+            logger.warning(
+                "restore.suppression_leak: sentinel still failover-suppressed outside a "
+                "restore; resuming failover on this unit"
+            )
+            self.resume_local_failover()
+        except ValkeyWorkloadCommandError as e:
+            logger.warning("Could not check sentinel failover suppression: %s", e)
+
     def _resume_failover_on(self, endpoint: str) -> None:
         client = self._get_sentinel_client()
         if not client.set(

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -390,6 +390,7 @@ class SentinelManager(ManagerStatusProtocol):
                 str(SENTINEL_DOWN_AFTER_SUPPRESSED_MS),
             ):
                 raise SentinelFailoverError(f"Failed to suppress failover on sentinel {endpoint}")
+        logger.info("restore.failover_suppressed: down-after raised on every sentinel")
 
     def resume_failover(self) -> None:
         """Reset down-after and SENTINEL RESET on every sentinel; idempotent.
@@ -401,6 +402,7 @@ class SentinelManager(ManagerStatusProtocol):
         """
         for endpoint in self.all_sentinel_endpoints():
             self._resume_failover_on(endpoint)
+        logger.info("restore.failover_resumed: down-after reset on every sentinel")
 
     def resume_local_failover(self) -> None:
         """Reset down-after and SENTINEL RESET on this unit's sentinel only."""

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -394,17 +394,31 @@ class SentinelManager(ManagerStatusProtocol):
     def resume_failover(self) -> None:
         """Reset down-after and SENTINEL RESET on every sentinel; idempotent.
 
-        Best-effort on a non-OK SET (logged, not raised) — raising on a teardown
-        path would re-wedge the restore. A stuck value clears on the next config
-        re-render (Sentinel persists SET to its own conf, so a restart won't).
+        Best-effort on a non-OK SET (logged, not raised) — raising on a restore-
+        failure path would re-wedge the restore. A sentinel left stuck (unreachable
+        here; it persists SET to its own conf, so a restart won't clear it) is
+        self-healed by its own unit via is_failover_suppressed/resume_local_failover.
         """
-        client = self._get_sentinel_client()
         for endpoint in self.all_sentinel_endpoints():
-            if not client.set(
-                endpoint, PRIMARY_NAME, "down-after-milliseconds", str(SENTINEL_DOWN_AFTER_MS)
-            ):
-                logger.warning("Failed to reset down-after-milliseconds on sentinel %s", endpoint)
-            client.reset(hostname=endpoint)
+            self._resume_failover_on(endpoint)
+
+    def resume_local_failover(self) -> None:
+        """Reset down-after and SENTINEL RESET on this unit's sentinel only."""
+        self._resume_failover_on(self.state.endpoint)
+
+    def is_failover_suppressed(self) -> bool:
+        """Whether this unit's sentinel still has the restore-suppressed down-after."""
+        client = self._get_sentinel_client()
+        down_after = client.primary(hostname=self.state.endpoint).get("down-after-milliseconds")
+        return str(down_after) == str(SENTINEL_DOWN_AFTER_SUPPRESSED_MS)
+
+    def _resume_failover_on(self, endpoint: str) -> None:
+        client = self._get_sentinel_client()
+        if not client.set(
+            endpoint, PRIMARY_NAME, "down-after-milliseconds", str(SENTINEL_DOWN_AFTER_MS)
+        ):
+            logger.warning("Failed to reset down-after-milliseconds on sentinel %s", endpoint)
+        client.reset(hostname=endpoint)
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Compute the sentinel manager's statuses."""

--- a/tests/integration/backup/helpers.py
+++ b/tests/integration/backup/helpers.py
@@ -24,6 +24,7 @@ def deploy_and_relate_s3(
     charm: str,
     substrate: Substrate,
     microceph: dict,
+    num_units: int = 3,
 ) -> None:
     """Deploy the local valkey charm + s3-integrator, wire S3 creds/TLS, and relate them.
 
@@ -32,6 +33,8 @@ def deploy_and_relate_s3(
     scenario removes only the valkey app -- s3-integrator, its credentials secret,
     and its config persist -- so the whole s3-integrator setup is guarded on its
     presence and the valkey app is (re)deployed and (re)related on its own.
+    ``num_units`` only applies to a fresh valkey deploy (an existing app is left
+    at its current size).
     """
     status = juju.status()
 
@@ -70,7 +73,7 @@ def deploy_and_relate_s3(
         juju.deploy(
             charm,
             resources=IMAGE_RESOURCE if substrate == Substrate.K8S else None,
-            num_units=3,
+            num_units=num_units,
             trust=True,
         )
 

--- a/tests/integration/backup/test_s3_restore.py
+++ b/tests/integration/backup/test_s3_restore.py
@@ -342,7 +342,6 @@ def test_failed_restore_not_wedged_when_leader_not_primary(
     primary left restore_id set forever -- the app stuck in RESTORE_IN_PROGRESS,
     backups blocked. Here we force primary != leader, fail a restore, and assert
     the leader tears it down (RESTORE_FAILED) and the cluster is usable again.
-    (PR #79 review, Mehdi-Bendriss r3547362621.)
     """
     # Independently runnable (deploy_and_relate_s3 is idempotent).
     deploy_and_relate_s3(juju, charm, substrate, microceph)
@@ -404,7 +403,7 @@ def test_restore_single_unit(
     self-delivery (with update-status as the backstop). Also checks the unit is
     writable again afterwards -- the restart resets the rendered
     min-replicas-to-write=1, which a lone primary can never satisfy, so the
-    post-restore reconcile must relax it (PR #79 review, skourta r3794577942).
+    post-restore reconcile must relax it.
     """
     # Start from a fresh 1-unit app; the earlier scenarios leave a 3-unit one.
     if APP_NAME in juju.status().apps:

--- a/tests/integration/backup/test_s3_restore.py
+++ b/tests/integration/backup/test_s3_restore.py
@@ -4,11 +4,13 @@
 
 """Integration tests for S3 restore against MicroCeph.
 
-Three scenarios:
-  1. rollback      – write → backup → mutate → restore → original value back on all units.
+Scenarios:
+  1. rollback          – write → backup → mutate → restore → original value back on all units.
   2. disaster-recovery – write → backup → remove app → redeploy → restore → data back.
   3. corrupt-restore   – attempt restore of a corrupt S3 object → old data preserved →
                          Sentinel failover still works (suppression-leak regression guard).
+  4. leader ≠ primary  – a failed restore on a non-leader primary must not wedge the cluster.
+  5. single unit       – happy path on a 1-unit app: no replicas, no resync, leader == primary.
 
 Run only with a bootstrapped Juju controller and built charm:
     tox run -e integration -- tests/integration/backup/test_s3_restore.py --substrate k8s
@@ -383,3 +385,54 @@ def test_failed_restore_not_wedged_when_leader_not_primary(
         f"create-backup blocked after a failed non-leader-primary restore "
         f"(restore_id wedged?): {task.stderr}"
     )
+
+
+@pytest.mark.abort_on_fail
+def test_restore_single_unit(
+    charm: str,
+    juju: jubilant.Juju,
+    microceph: dict,
+    s3_bucket,
+    substrate: Substrate,
+) -> None:
+    """Happy path on a single-unit app: write → backup → mutate → restore → original back.
+
+    A one-unit cluster takes a different path from the 3-unit scenarios above: the
+    only participant is both juju leader and valkey primary, there is no replica
+    RESYNC, the barrier has a single member, and the RESTORE → RESYNC → COMPLETED
+    cascade is driven purely by the leader's own app-databag relation-changed
+    self-delivery (with update-status as the backstop). Also checks the unit is
+    writable again afterwards -- the restart resets the rendered
+    min-replicas-to-write=1, which a lone primary can never satisfy, so the
+    post-restore reconcile must relax it (PR #79 review, skourta r3794577942).
+    """
+    # Start from a fresh 1-unit app; the earlier scenarios leave a 3-unit one.
+    if APP_NAME in juju.status().apps:
+        juju.remove_application(APP_NAME)
+        juju.wait(lambda s: APP_NAME not in s.apps, timeout=600, delay=5)
+    deploy_and_relate_s3(juju, charm, substrate, microceph, num_units=1)
+    assert len(juju.status().apps[APP_NAME].units) == 1
+
+    _write_key(juju, "single_unit_key", "original")
+
+    task = juju.run(f"{APP_NAME}/leader", "create-backup")
+    assert task.success, task.stderr
+    backup_id = task.results["backup-id"]
+    assert BACKUP_ID_RE.match(backup_id), f"Unexpected backup-id format: {backup_id!r}"
+
+    _write_key(juju, "single_unit_key", "mutated")
+
+    task = juju.run(f"{APP_NAME}/leader", "restore", {"backup-id": backup_id})
+    assert task.success, task.stderr
+    assert "restore" in task.results, f"Unexpected action results: {task.results}"
+
+    _wait_restore_active(juju)
+
+    unit_name = _leader_unit_name(juju)
+    got = _read_key(juju, unit_name, "single_unit_key")
+    assert got == "original", f"Expected 'original' on {unit_name}, got {got!r}"
+
+    # Writable after the restore restart (min-replicas-to-write relaxed for a lone primary).
+    _write_key(juju, "single_unit_post_restore", "ok")
+    got = _read_key(juju, unit_name, "single_unit_post_restore")
+    assert got == "ok", f"Single unit not writable after restore; got {got!r}"

--- a/tests/integration/backup/test_s3_restore.py
+++ b/tests/integration/backup/test_s3_restore.py
@@ -233,7 +233,7 @@ def test_corrupt_restore_keeps_cluster_and_failover(
     """A failed restore leaves old data intact and failover suppression is resumed.
 
     Regression guard for the suppression-leak bug: if suppress_failover() is not
-    matched by resume_failover() on the _restore_teardown path, sentinel's
+    matched by resume_failover() on the _fail_restore path, sentinel's
     down-after-milliseconds stays at the suppressed value and the cluster
     silently loses automatic failover.
     """
@@ -247,13 +247,13 @@ def test_corrupt_restore_keeps_cluster_and_failover(
     # Initiate a restore of the corrupt object.  The action itself succeeds
     # (the backup-id is present in S3 and matches _BACKUP_ID_RE), but the
     # async download step raises ValkeyRestoreError on the magic-byte check,
-    # causing _restore_teardown() to call resume_failover() and set RESTORE_FAILED.
+    # causing _fail_restore() to call resume_failover() and set RESTORE_FAILED.
     task = juju.run(f"{APP_NAME}/leader", "restore", {"backup-id": corrupt_id})
     assert task.success, task.stderr
     assert "restore" in task.results, f"Unexpected action results: {task.results}"
 
     # The corrupt object fails the magic-byte check in the restore step, so the
-    # workflow tears down and the leader records RESTORE_FAILED on the app. Wait
+    # workflow fails and the leader records RESTORE_FAILED on the app. Wait
     # on that status -- a real convergence signal -- rather than a bare sleep,
     # and settle the agents before probing data.
     juju.wait(
@@ -271,14 +271,14 @@ def test_corrupt_restore_keeps_cluster_and_failover(
     got = _read_key(juju, _leader_unit_name(juju), "safe_key")
     assert got == "safe-value", f"Old data lost after corrupt restore; got {got!r}"
 
-    # _restore_teardown must have resumed failover: every sentinel's
+    # _fail_restore must have resumed failover: every sentinel's
     # down-after-milliseconds is back to normal, not the suppressed value. Checked
     # directly -- a leak leaves it at the suppressed value -- rather than killing
     # the primary and waiting for a real failover, which on K8s races Pebble's
     # auto-restart of the process and is not a reliable signal of suppression.
     down_after = _sentinel_down_after_ms(juju)
     assert all(ms == SENTINEL_DOWN_AFTER_MS for ms in down_after.values()), (
-        "Failover suppression not resumed on corrupt-restore teardown "
+        "Failover suppression not resumed after the corrupt restore failed "
         f"(suppression-leak regression): down-after-milliseconds={down_after}, "
         f"expected {SENTINEL_DOWN_AFTER_MS} on every sentinel."
     )

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -763,7 +763,11 @@ def test_on_create_backup_action_happy(mocker):
 
 
 def test_on_create_backup_action_audit_logs_invocation(mocker, caplog):
-    """Each create-backup invocation is audit-logged with its action id and unit."""
+    """Each create-backup invocation is audit-logged with its action id.
+
+    No unit name in the message -- Juju already prefixes every log line with
+    the unit that emitted it.
+    """
     import logging
 
     from src.events.backup import BackupEvents
@@ -784,7 +788,7 @@ def test_on_create_backup_action_audit_logs_invocation(mocker, caplog):
     audit = [r.message for r in caplog.records if "audit: create-backup" in r.message]
     assert audit, "expected an audit log line for the action invocation"
     assert "action_id=42" in audit[0]
-    assert "unit=valkey/2" in audit[0]
+    assert "unit=" not in audit[0]
 
 
 def test_on_create_backup_action_fails_when_guard_blocks(mocker):

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -109,3 +109,26 @@ def test_wait_until_resynced_times_out_raises_not_ready(mocker):
 
     with pytest.raises(ValkeyClusterNotReadyError):
         cm.wait_until_resynced(900)
+
+
+def test_bounded_waits_log_their_own_progress(mocker, caplog):
+    """The restore waits log where they happen -- in the manager, not the event handler.
+
+    Log output belongs in the manager method that does the work, so the event
+    flow stays readable.
+    """
+    import logging
+
+    cm, client = _cluster_manager_with_client()
+    client.ping.return_value = True
+    client.info_persistence.return_value = {"loading": "0"}
+    cm.is_replica_synced = MagicMock(return_value=True)
+
+    with caplog.at_level(logging.INFO):
+        cm.wait_until_loaded(600)
+        cm.wait_until_resynced(900)
+
+    assert "restore.wait: dataset to load (up to 600s)" in caplog.text
+    assert "restore.wait: dataset loaded" in caplog.text
+    assert "restore.wait: replica resync (up to 900s)" in caplog.text
+    assert "restore.wait: replica resynced" in caplog.text

--- a/tests/unit/test_ip_change_reconcile.py
+++ b/tests/unit/test_ip_change_reconcile.py
@@ -54,10 +54,12 @@ def _reconcile_env() -> ExitStack:
         patch("managers.auth.AuthManager.configure_auth"),
         patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.1.2"),
         patch("managers.sentinel.SentinelManager.restart_service"),
-        # stands in for `openssl x509 -ext subjectAltName`: the on-disk SANs carry OLD_IP
+        # stands in for `openssl x509 -ext subjectAltName`: the on-disk SANs carry OLD_IP.
+        # exec returns (stdout, stderr) -- the second element matters because other
+        # update-status work unpacks both.
         patch(
             "workload_vm.ValkeyVmWorkload.exec",
-            return_value=(f"DNS:www.example.com, IP Address:{OLD_IP}",),
+            return_value=(f"DNS:www.example.com, IP Address:{OLD_IP}", None),
         ),
         patch("workload_vm.ValkeyVmWorkload.restart"),
         patch("managers.tls.TLSManager.build_sans_ip", return_value=frozenset({NEW_IP})),
@@ -68,6 +70,9 @@ def _reconcile_env() -> ExitStack:
         patch("managers.cluster.ClusterManager.is_healthy", return_value=True),
         patch("managers.sentinel.SentinelManager.is_healthy", return_value=True),
         patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write"),
+        # unrelated update-status self-heal: it would otherwise drive the sentinel
+        # CLI through the openssl stub above.
+        patch("managers.sentinel.SentinelManager.reconcile_failover_suppression"),
     )
     stack = ExitStack()
     for p in patches:

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -310,6 +310,50 @@ def test_resume_failover_best_effort_on_non_ok_set(mocker, caplog):
     assert "10.0.0.1" in caplog.text  # the non-OK endpoint was logged
 
 
+def test_is_failover_suppressed_reads_local_sentinel_down_after(mocker):
+    """is_failover_suppressed is a local read: this unit's sentinel, suppressed value only."""
+    from src.literals import SENTINEL_DOWN_AFTER_MS, SENTINEL_DOWN_AFTER_SUPPRESSED_MS
+    from src.managers.sentinel import SentinelManager
+
+    mgr = SentinelManager.__new__(SentinelManager)
+    mgr.state = mocker.Mock(endpoint="10.0.0.1")
+    client = mocker.Mock()
+    mocker.patch.object(mgr, "_get_sentinel_client", return_value=client)
+
+    client.primary.return_value = {
+        "down-after-milliseconds": str(SENTINEL_DOWN_AFTER_SUPPRESSED_MS)
+    }
+    assert mgr.is_failover_suppressed() is True
+    client.primary.assert_called_once_with(hostname="10.0.0.1")
+
+    client.primary.return_value = {"down-after-milliseconds": str(SENTINEL_DOWN_AFTER_MS)}
+    assert mgr.is_failover_suppressed() is False
+    client.primary.return_value = {}  # field missing: not suppressed
+    assert mgr.is_failover_suppressed() is False
+
+
+def test_resume_local_failover_targets_only_this_sentinel(mocker):
+    """resume_local_failover resets + RESETs this unit's sentinel and no other."""
+    from src.literals import PRIMARY_NAME, SENTINEL_DOWN_AFTER_MS
+    from src.managers.sentinel import SentinelManager
+
+    mgr = SentinelManager.__new__(SentinelManager)
+    mgr.state = mocker.Mock(endpoint="10.0.0.1")
+    client = mocker.Mock()
+    mocker.patch.object(mgr, "_get_sentinel_client", return_value=client)
+    all_endpoints = mocker.patch.object(
+        mgr, "all_sentinel_endpoints", return_value=["10.0.0.1", "10.0.0.2"]
+    )
+
+    mgr.resume_local_failover()
+
+    client.set.assert_called_once_with(
+        "10.0.0.1", PRIMARY_NAME, "down-after-milliseconds", str(SENTINEL_DOWN_AFTER_MS)
+    )
+    client.reset.assert_called_once_with(hostname="10.0.0.1")
+    all_endpoints.assert_not_called()
+
+
 def test_sentinel_is_failover_in_progress_reads_flags(mocker):
     """Manager helper reports failover from the primary flags with no retry/blocking."""
     from src.managers.sentinel import SentinelManager
@@ -783,6 +827,12 @@ def restore_managers(mocker):
         roll_back=mocker.patch("managers.backup.BackupManager.roll_back"),
         suppress_failover=mocker.patch("managers.sentinel.SentinelManager.suppress_failover"),
         resume_failover=mocker.patch("managers.sentinel.SentinelManager.resume_failover"),
+        is_failover_suppressed=mocker.patch(
+            "managers.sentinel.SentinelManager.is_failover_suppressed", return_value=False
+        ),
+        resume_local_failover=mocker.patch(
+            "managers.sentinel.SentinelManager.resume_local_failover"
+        ),
         save_dataset_before_shutdown=mocker.patch(
             "managers.cluster.ClusterManager.save_dataset_before_shutdown"
         ),
@@ -1605,6 +1655,54 @@ def test_completed_restore_clears_terminal_statuses(mocker, cloud_spec, restore_
 # These assert one guard clause on a handler that otherwise has nothing to do
 # with restore; driving them through full events would entangle unrelated
 # handlers (and re-run the restore workflow), so they stay at the unit layer.
+
+
+def test_update_status_resumes_failover_left_suppressed(mocker, cloud_spec, restore_managers):
+    """A sentinel still at the suppressed down-after outside a restore is resumed.
+
+    resume_failover is best-effort on every teardown path and Sentinel persists
+    SENTINEL SET to its own conf, so a sentinel unreachable at teardown would
+    otherwise stay failover-suppressed until the next config re-render (PR #79
+    review, skourta r3621161292). Each unit self-heals its own sentinel on
+    update-status.
+    """
+    restore_managers.is_failover_suppressed.return_value = True
+    ctx, state = _restore_context_and_state(cloud_spec)  # no restore in progress
+
+    ctx.run(ctx.on.update_status(), state)
+
+    restore_managers.resume_local_failover.assert_called_once()
+
+
+def test_update_status_keeps_suppression_during_restore(mocker, cloud_spec, restore_managers):
+    """Suppression is by design mid-restore: the self-heal must not undo it."""
+    restore_managers.is_failover_suppressed.return_value = True
+    ctx, state = _restore_context_and_state(
+        cloud_spec,
+        app_data={
+            "restore-id": "2026-05-13T10:00:00Z",
+            "restore-instruction": RestoreStep.RESTORE.value,
+            "restore-participants": "valkey/0",
+        },
+    )
+
+    ctx.run(ctx.on.update_status(), state)
+
+    restore_managers.resume_local_failover.assert_not_called()
+
+
+def test_update_status_suppression_check_tolerates_sentinel_error(
+    mocker, cloud_spec, restore_managers
+):
+    """A sentinel that can't be queried is skipped (retried next update-status), not a crash."""
+    from common.exceptions import ValkeyWorkloadCommandError
+
+    restore_managers.is_failover_suppressed.side_effect = ValkeyWorkloadCommandError("down")
+    ctx, state = _restore_context_and_state(cloud_spec)
+
+    ctx.run(ctx.on.update_status(), state)  # must not raise
+
+    restore_managers.resume_local_failover.assert_not_called()
 
 
 def test_storage_detaching_refuses_during_restore(mocker):

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -4,7 +4,7 @@
 
 """Unit tests for the S3 restore feature.
 
-Two layers, on purpose (PR #79 review, reneradoi):
+Two layers, on purpose:
 
 * The restore **state machine** and the **restore action** are exercised through
   real Juju events (``ctx.on.action`` / ``ctx.on.update_status``) via
@@ -146,8 +146,8 @@ def test_workload_start_stop_alive_take_optional_service():
         param = inspect.signature(getattr(WorkloadBase, name)).parameters.get("service")
         assert param is not None and param.default is None
 
-    # Liveness verification is an explicit opt-in/out, decoupled from `service`
-    # (PR #79 review, reneradoi): start verifies by default, stop does not.
+    # Liveness verification is an explicit opt-in/out, decoupled from `service`:
+    # start verifies by default, stop does not.
     assert inspect.signature(WorkloadBase.start).parameters["check_alive"].default is True
     assert inspect.signature(WorkloadBase.stop).parameters["check_alive"].default is False
 
@@ -705,7 +705,7 @@ def test_restore_blocked_gracefully_when_sentinel_query_errors(mocker):
 
 
 def test_restore_guard_covers_the_backup_id_checks(mocker):
-    """The backup-id checks are gates like any other (PR #96 review, skourta r3813059183)."""
+    """The backup-id checks are gates like any other, ordered after the cheap ones."""
     ev = _passing_restore_guard(mocker)
 
     assert "backup-id" in (ev._restore_blocking_reason("") or "")
@@ -776,7 +776,7 @@ def test_blocking_reason_blocks_backup_during_restore(mocker):
 # ── event-driven (ops.testing / Scenario) ────────────────────────────────────
 #
 # The restore action + state machine are driven through real Juju events so the
-# peer-relation data-interface wiring is part of the test, per PR #79 review.
+# peer-relation data-interface wiring is part of the test.
 
 
 def _restore_context_and_state(
@@ -831,7 +831,7 @@ def _peer_unit_data(state):
 def _drive_restore(ctx, state, *, capture_statuses=False):
     """Drive the restore workflow to a fixed point across hooks.
 
-    The workflow advances one step per hook (no in-hook loop, PR #79 review): in
+    The workflow advances one step per hook (no in-hook loop): in
     real Juju each leader app-databag write re-delivers relation_changed, with
     update_status as a backstop. ops.testing emits one event and can't model a
     peer relation_changed for the leader's own app-data write (no remote unit),
@@ -939,8 +939,8 @@ def test_restore_action_initiates_workflow(mocker, cloud_spec, restore_managers)
 def test_restore_action_logs_every_rejection(mocker, cloud_spec, restore_managers, caplog):
     """Every rejected restore action leaves a traceable log line, not just a failed task.
 
-    PR #79 review (skourta r3794362707): the action result is transient; the
-    unit log must show why a restore didn't start.
+    The action result is transient; the unit log must show why a restore
+    didn't start.
     """
     import logging
 
@@ -1022,7 +1022,7 @@ def test_single_unit_restore_completes_via_relation_changed_cascade(cloud_spec, 
     A single unit is always the leader, and Juju delivers relation_changed to the
     leader for its own writes to the peer *app* databag, so the machine cascades
     forward one step per hook off the restore_id/instruction writes -- no peers
-    and no in-hook loop needed (PR #79 review, reneradoi).
+    and no in-hook loop needed.
     """
     ctx, state = _restore_context_and_state(
         cloud_spec,
@@ -1534,7 +1534,7 @@ def test_restore_failure_unhealthy_status(cloud_spec, restore_managers):
 # juju leader, and only the leader can clear the app-level restore_id. A failing
 # non-leader unit must therefore signal failure on its OWN unit databag so the
 # leader can tear the restore down, instead of silently wedging the whole cluster
-# in "restore in progress" forever. (PR #79 review, Mehdi-Bendriss r3547362621.)
+# in "restore in progress" forever.
 
 
 def test_non_leader_primary_failure_records_failure_marker(cloud_spec, restore_managers):
@@ -1765,9 +1765,8 @@ def test_update_status_resumes_failover_left_suppressed(mocker, cloud_spec, rest
 
     resume_failover is best-effort on every teardown path and Sentinel persists
     SENTINEL SET to its own conf, so a sentinel unreachable at teardown would
-    otherwise stay failover-suppressed until the next config re-render (PR #79
-    review, skourta r3621161292). Each unit self-heals its own sentinel on
-    update-status.
+    otherwise stay failover-suppressed until the next config re-render. Each
+    unit self-heals its own sentinel on update-status.
     """
     restore_managers.is_failover_suppressed.return_value = True
     ctx, state = _restore_context_and_state(cloud_spec)  # no restore in progress

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -1802,11 +1802,10 @@ def test_completed_restore_clears_terminal_statuses(mocker, cloud_spec, restore_
     assert RestoreStatuses.RESTORE_UNHEALTHY.value in deleted
 
 
-# ── restore-awareness guards (single early-return clauses) ────────────────────
+# ── failover-suppression self-heal ───────────────────────────────────────────
 #
-# These assert one guard clause on a handler that otherwise has nothing to do
-# with restore; driving them through full events would entangle unrelated
-# handlers (and re-run the restore workflow), so they stay at the unit layer.
+# The workflow's "no restore in progress" branch also resumes a sentinel a failed
+# restore left suppressed, so it runs on every hook the workflow observes.
 
 
 def test_update_status_resumes_failover_left_suppressed(mocker, cloud_spec, restore_managers):
@@ -1815,12 +1814,40 @@ def test_update_status_resumes_failover_left_suppressed(mocker, cloud_spec, rest
     resume_failover is best-effort on every teardown path and Sentinel persists
     SENTINEL SET to its own conf, so a sentinel unreachable at teardown would
     otherwise stay failover-suppressed until the next config re-render. Each
-    unit self-heals its own sentinel on update-status.
+    unit self-heals its own sentinel, with update-status as the periodic backstop.
     """
     restore_managers.is_failover_suppressed.return_value = True
+    # A resume clears the suppression, so a hook that re-enters the workflow (a
+    # single-unit deployment re-emits peer relation-changed from the TLS handler)
+    # heals once and then reads the configured value.
+    restore_managers.resume_local_failover.side_effect = lambda: setattr(
+        restore_managers.is_failover_suppressed, "return_value", False
+    )
     ctx, state = _restore_context_and_state(cloud_spec)  # no restore in progress
 
     ctx.run(ctx.on.update_status(), state)
+
+    restore_managers.resume_local_failover.assert_called_once()
+
+
+def test_peer_relation_changed_resumes_failover_left_suppressed(
+    mocker, cloud_spec, restore_managers
+):
+    """The self-heal also runs on the peer hook, not only on the 5-minute backstop.
+
+    A restore ends by clearing the app-level restore-id, which re-delivers peer
+    relation-changed to every unit -- exactly when a sentinel left suppressed by a
+    best-effort teardown should be caught, rather than up to an update-status later.
+    """
+    restore_managers.is_failover_suppressed.return_value = True
+    ctx, state = _restore_context_and_state(
+        cloud_spec,
+        leader=False,  # no restore in progress
+        peers_data={1: {"start-state": "started"}},
+    )
+    peer = next(r for r in state.relations if r.id == 1)
+
+    ctx.run(ctx.on.relation_changed(peer, remote_unit=1), state)
 
     restore_managers.resume_local_failover.assert_called_once()
 
@@ -1854,6 +1881,13 @@ def test_update_status_suppression_check_tolerates_sentinel_error(
     ctx.run(ctx.on.update_status(), state)  # must not raise
 
     restore_managers.resume_local_failover.assert_not_called()
+
+
+# ── restore-awareness guards (single early-return clauses) ────────────────────
+#
+# These assert one guard clause on a handler that otherwise has nothing to do
+# with restore; driving them through full events would entangle unrelated
+# handlers (and re-run the restore workflow), so they stay at the unit layer.
 
 
 def test_storage_detaching_refuses_during_restore(mocker):

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -354,6 +354,33 @@ def test_resume_local_failover_targets_only_this_sentinel(mocker):
     all_endpoints.assert_not_called()
 
 
+def test_reconcile_failover_suppression_is_a_manager_op(mocker, caplog):
+    """The self-heal lives in the sentinel manager: resume only a still-suppressed sentinel."""
+    import logging
+
+    from common.exceptions import ValkeyWorkloadCommandError
+    from src.managers.sentinel import SentinelManager
+
+    mgr = SentinelManager.__new__(SentinelManager)
+    suppressed = mocker.patch.object(mgr, "is_failover_suppressed", return_value=False)
+    resume = mocker.patch.object(mgr, "resume_local_failover")
+
+    mgr.reconcile_failover_suppression()
+    resume.assert_not_called()
+
+    suppressed.return_value = True
+    with caplog.at_level(logging.WARNING):
+        mgr.reconcile_failover_suppression()
+    resume.assert_called_once()
+    assert "suppression_leak" in caplog.text
+
+    # An unreachable sentinel is skipped (retried next update-status), never a crash.
+    resume.reset_mock()
+    suppressed.side_effect = ValkeyWorkloadCommandError("down")
+    mgr.reconcile_failover_suppression()  # must not raise
+    resume.assert_not_called()
+
+
 def test_sentinel_is_failover_in_progress_reads_flags(mocker):
     """Manager helper reports failover from the primary flags with no retry/blocking."""
     from src.managers.sentinel import SentinelManager

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -667,6 +667,7 @@ def _passing_restore_guard(mocker):
 
     ev = BackupEvents.__new__(BackupEvents)
     ev.charm = mocker.Mock()
+    ev.charm.backup_manager.list_backups.return_value = ["b1"]
     ev.charm.unit.is_leader.return_value = True
     ev.charm.state.s3_relation = True
     ev.charm.state.cluster.s3_credentials = True
@@ -680,14 +681,14 @@ def _passing_restore_guard(mocker):
 
 
 def test_restore_guard_passes_when_all_gates_ok(mocker):
-    assert _passing_restore_guard(mocker)._restore_blocking_reason() is None
+    assert _passing_restore_guard(mocker)._restore_blocking_reason("b1") is None
 
 
 def test_restore_blocked_during_tls_transition(mocker):
     """A restore restarts the primary; refuse to start one mid-TLS-transition."""
     ev = _passing_restore_guard(mocker)
     ev.charm.state.is_tls_transitioning = True
-    reason = ev._restore_blocking_reason()
+    reason = ev._restore_blocking_reason("b1")
     assert reason is not None and "tls" in reason.lower()
 
 
@@ -699,8 +700,32 @@ def test_restore_blocked_gracefully_when_sentinel_query_errors(mocker):
     ev.charm.sentinel_manager.is_failover_in_progress.side_effect = ValkeyWorkloadCommandError(
         "sentinel unreachable"
     )
-    reason = ev._restore_blocking_reason()  # must NOT raise
+    reason = ev._restore_blocking_reason("b1")  # must NOT raise
     assert reason is not None
+
+
+def test_restore_guard_covers_the_backup_id_checks(mocker):
+    """The backup-id checks are gates like any other (PR #96 review, skourta r3813059183)."""
+    ev = _passing_restore_guard(mocker)
+
+    assert "backup-id" in (ev._restore_blocking_reason("") or "")
+    ev.charm.backup_manager.list_backups.assert_not_called()  # cheap gates first
+
+    reason = ev._restore_blocking_reason("nope")
+    assert reason is not None and "not found" in reason
+
+
+def test_restore_guard_blocks_gracefully_when_listing_fails(mocker):
+    """An S3 listing error blocks the restore with a safe reason, not a traceback at the user."""
+    from common.exceptions import ValkeyBackupError
+
+    ev = _passing_restore_guard(mocker)
+    ev.charm.backup_manager.list_backups.side_effect = ValkeyBackupError("bucket on fire")
+
+    reason = ev._restore_blocking_reason("b1")  # must NOT raise
+
+    assert reason is not None and "list backups" in reason
+    assert "bucket on fire" not in reason  # detail goes to the unit log only
 
 
 def test_credentials_rotation_defers_during_restore(mocker):

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -397,6 +397,29 @@ def test_sentinel_is_failover_in_progress_reads_flags(mocker):
     assert mgr.is_failover_in_progress() is False
 
 
+def test_failover_suppression_logs_in_the_manager(mocker, caplog):
+    """suppress/resume log their own effect, so the event handler doesn't have to.
+
+    The log line belongs next to the work it describes.
+    """
+    import logging
+
+    from src.managers.sentinel import SentinelManager
+
+    mgr = SentinelManager.__new__(SentinelManager)
+    client = mocker.Mock()
+    client.set.return_value = True
+    mocker.patch.object(mgr, "_get_sentinel_client", return_value=client)
+    mocker.patch.object(mgr, "all_sentinel_endpoints", return_value=["10.0.0.1"])
+
+    with caplog.at_level(logging.INFO):
+        mgr.suppress_failover()
+        mgr.resume_failover()
+
+    assert "restore.failover_suppressed" in caplog.text
+    assert "restore.failover_resumed" in caplog.text
+
+
 # ── backup manager: download / verify / restore primitives ───────────────────
 
 
@@ -491,6 +514,28 @@ def test_next_restore_step():
     assert BackupManager.next_restore_step(RestoreStep.NOT_STARTED) == RestoreStep.RESTORE
     assert BackupManager.next_restore_step(RestoreStep.RESTORE) == RestoreStep.RESYNC
     assert BackupManager.next_restore_step(RestoreStep.RESYNC) == RestoreStep.COMPLETED
+
+
+def test_set_restore_step_logs_the_completed_step(mocker, caplog):
+    """The step-completed line lives in the manager that writes the databag.
+
+    The log belongs next to the work, and the unit name is dropped -- Juju
+    already prefixes every log line with it.
+    """
+    import logging
+
+    from src.literals import RestoreStep
+    from src.managers.backup import BackupManager
+
+    mgr = BackupManager.__new__(BackupManager)
+    mgr.state = mocker.Mock()
+
+    with caplog.at_level(logging.INFO):
+        mgr.set_restore_step(RestoreStep.RESYNC)
+
+    mgr.state.unit_server.update.assert_called_once_with({"restore_step": "resync"})
+    assert "restore.step_done step=resync" in caplog.text
+    assert "unit=" not in caplog.text
 
 
 def test_restore_on_primary_orders_stop_backup_download_start(mocker):
@@ -985,6 +1030,10 @@ def test_restore_workflow_logs_each_transition(cloud_spec, restore_managers, cap
         "restore.completed",
     ):
         assert marker in caplog.text, f"missing log marker {marker!r}"
+    # The event handler keeps only the state-machine trail -- per-step work
+    # logs itself in its manager (mocked out here) -- and never repeats the unit
+    # name Juju already prefixes onto every line.
+    assert "unit=" not in caplog.text
 
 
 def test_restore_action_rejected_on_non_leader(cloud_spec):

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -884,6 +884,57 @@ def test_restore_action_initiates_workflow(mocker, cloud_spec, restore_managers)
     restore_managers.restore_on_primary.assert_not_called()
 
 
+def test_restore_action_logs_every_rejection(mocker, cloud_spec, restore_managers, caplog):
+    """Every rejected restore action leaves a traceable log line, not just a failed task.
+
+    PR #79 review (skourta r3794362707): the action result is transient; the
+    unit log must show why a restore didn't start.
+    """
+    import logging
+
+    from ops.testing import ActionFailed
+
+    _pass_restore_preconditions(mocker, ["2026-05-13T10:00:00Z"])
+    ctx, state = _restore_context_and_state(cloud_spec)
+
+    with caplog.at_level(logging.WARNING), pytest.raises(ActionFailed):
+        ctx.run(ctx.on.action("restore", params={"backup-id": "2026-01-01T00:00:00Z"}), state)
+    assert "restore.rejected" in caplog.text
+    assert "2026-01-01T00:00:00Z" in caplog.text  # the unknown backup-id is in the log
+
+    caplog.clear()
+    ctx, state = _restore_context_and_state(cloud_spec, leader=False)
+    with caplog.at_level(logging.WARNING), pytest.raises(ActionFailed):
+        ctx.run(ctx.on.action("restore", params={"backup-id": "2026-05-13T10:00:00Z"}), state)
+    assert "restore.rejected" in caplog.text
+    assert "leader" in caplog.text
+
+
+def test_restore_workflow_logs_each_transition(cloud_spec, restore_managers, caplog):
+    """A full restore leaves a step-by-step trail in the unit log (review: hard to follow)."""
+    import logging
+
+    ctx, state = _restore_context_and_state(
+        cloud_spec,
+        app_data={
+            "restore-id": "2026-05-13T10:00:00Z",
+            "restore-instruction": RestoreStep.RESTORE.value,
+            "restore-participants": "valkey/0",
+        },
+    )
+
+    with caplog.at_level(logging.INFO):
+        _drive_restore(ctx, state)
+
+    for marker in (
+        "restore.step",  # a step ran on this unit
+        "role=primary",
+        "restore.advance",  # the leader moved the barrier
+        "restore.completed",
+    ):
+        assert marker in caplog.text, f"missing log marker {marker!r}"
+
+
 def test_restore_action_rejected_on_non_leader(cloud_spec):
     """A follower must refuse restore and write nothing to the app databag."""
     from ops import testing
@@ -1227,7 +1278,7 @@ def test_leader_fails_restore_when_participant_departs(cloud_spec, restore_manag
     restore_managers.resume_failover.assert_called()
 
 
-def test_non_leader_does_not_teardown_departed_participant(cloud_spec, restore_managers):
+def test_non_leader_does_not_fail_restore_on_departed_participant(cloud_spec, restore_managers):
     """Only the leader may tear a restore down when a participant departs.
 
     A non-leader that observes a departed participant must leave app state alone
@@ -1286,7 +1337,7 @@ def test_non_participant_unit_skips_restore_workflow(cloud_spec, restore_manager
     from common.exceptions import ValkeyWorkloadCommandError
 
     # StartLock is withheld during a restore, so this newcomer's Valkey is down;
-    # is_primary() would raise -> broad except -> _restore_teardown -> resume_failover.
+    # is_primary() would raise -> broad except -> _fail_restore -> resume_failover.
     restore_managers.is_primary.side_effect = ValkeyWorkloadCommandError("not up")
     ctx, state = _restore_context_and_state(
         cloud_spec,
@@ -1340,7 +1391,7 @@ def test_non_participant_leader_advances_restore(cloud_spec, restore_managers):
     assert _peer_app_data(state_out)["restore-instruction"] == RestoreStep.RESYNC.value
 
 
-def test_bad_backup_tears_down_before_stopping_primary(cloud_spec, restore_managers):
+def test_bad_backup_fails_restore_before_stopping_primary(cloud_spec, restore_managers):
     """A non-RDB backup fails the pre-stop check: the primary is never stopped or rolled back."""
     from common.exceptions import ValkeyRestoreError
 
@@ -1359,7 +1410,7 @@ def test_bad_backup_tears_down_before_stopping_primary(cloud_spec, restore_manag
     restore_managers.restore_on_primary.assert_not_called()
     restore_managers.roll_back.assert_not_called()
     # Teardown resumes the suppression it turned on before validating — exactly
-    # once: the leader-self _clear_failed_restore skips the redundant backstop.
+    # once: the leader-self _finish_failed_restore skips the redundant backstop.
     restore_managers.resume_failover.assert_called_once()
     assert _peer_app_data(state_out).get("restore-id", "") == ""
 
@@ -1392,7 +1443,7 @@ def test_restore_failure_rolls_back_and_resumes_failover(cloud_spec, restore_man
 
     restore_managers.roll_back.assert_called_once()
     # The critical invariant: failover is resumed — exactly once on the
-    # leader-self path (teardown resumes; _clear_failed_restore skips the backstop).
+    # leader-self path (teardown resumes; _finish_failed_restore skips the backstop).
     restore_managers.resume_failover.assert_called_once()
     assert RestoreStatuses.RESTORE_FAILED.value in statuses
     assert _peer_app_data(state_out).get("restore-id", "") == ""
@@ -1463,7 +1514,7 @@ def test_non_leader_primary_failure_records_failure_marker(cloud_spec, restore_m
     assert _peer_unit_data(state_out)["restore-failed"] == "failed:tok-1"
 
 
-def test_leader_tears_down_when_peer_restore_failed(cloud_spec, restore_managers):
+def test_leader_ends_restore_when_peer_restore_failed(cloud_spec, restore_managers):
     """The leader clears the app-level restore state when a *peer* reports failure.
 
     valkey/1 (a non-leader) recorded a failure for this attempt's token; the
@@ -1500,7 +1551,7 @@ def test_leader_tears_down_when_peer_restore_failed(cloud_spec, restore_managers
     assert _peer_app_data(state_out).get("restore-id", "") == ""
 
 
-def test_teardown_records_failure_even_if_resume_failover_raises(cloud_spec, restore_managers):
+def test_fail_restore_records_failure_even_if_resume_failover_raises(cloud_spec, restore_managers):
     """A raising resume_failover must not abort teardown (else restore re-wedges).
 
     resume_failover hits every sentinel via the CLI and can raise; teardown must
@@ -1534,7 +1585,7 @@ def test_teardown_records_failure_even_if_resume_failover_raises(cloud_spec, res
     assert _peer_app_data(state_out).get("restore-id", "") == ""
 
 
-def test_clear_failed_restore_unwedges_before_status_add(mocker):
+def test_finish_failed_restore_unwedges_before_status_add(mocker):
     """The un-wedge must happen before, and independently of, the status write.
 
     statuses.add is not wrapped (matching the project convention); a failing add
@@ -1551,14 +1602,14 @@ def test_clear_failed_restore_unwedges_before_status_add(mocker):
     ev.charm.state.statuses.add.side_effect = RuntimeError("bad status databag")
 
     with pytest.raises(RuntimeError):
-        ev._clear_failed_restore(resume=False)
+        ev._finish_failed_restore(resume=False)
 
     # Restore state was cleared BEFORE the status write raised.
     ev.charm.state.cluster.update.assert_called_once()
     assert ev.charm.state.cluster.update.call_args.args[0]["restore_id"] == ""
 
 
-def test_clear_failed_restore_clears_state_before_resume_failover(mocker):
+def test_finish_failed_restore_clears_state_before_resume_failover(mocker):
     """State is cleared before resume_failover, so an unexpected resume error can't wedge.
 
     resume_failover is a best-effort backstop reached outside the workflow's
@@ -1574,7 +1625,7 @@ def test_clear_failed_restore_clears_state_before_resume_failover(mocker):
     ev.charm.sentinel_manager.resume_failover.side_effect = RuntimeError("sentinel unreachable")
 
     with pytest.raises(RuntimeError):
-        ev._clear_failed_restore(resume=True)
+        ev._finish_failed_restore(resume=True)
 
     # Cleared BEFORE the resume raised -> not wedged.
     ev.charm.state.cluster.update.assert_called_once()

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -487,7 +487,10 @@ def test_check_certificate_expiration(cloud_spec):
         model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
     )
 
-    with patch("workload_k8s.ValkeyK8sWorkload.exec", return_value="0"):
+    # exec returns (stdout, stderr); the openssl -checkend path only cares that it
+    # doesn't raise, and the sentinel down-after self-heal on update-status parses
+    # stdout as JSON.
+    with patch("workload_k8s.ValkeyK8sWorkload.exec", return_value=("{}", None)):
         state_out = ctx.run(ctx.on.update_status(), state_in)
         assert not state_out.get_relation(1).local_unit_data.get("tls-certificate-expiring")
         assert not status_is(state_out, TLSStatuses.CERTIFICATE_EXPIRING.value)


### PR DESCRIPTION
Follow-up to #79 (S3 restore) addressing the last review round (skourta, 2026-08-17).
Only the four commits on top of #79 are new; base becomes `9/edge` once #79 lands.

- **fix(restore): self-heal a sentinel left failover-suppressed** — `resume_failover` is
  best-effort on failure paths and Sentinel persists `SENTINEL SET` to its own conf, so a
  sentinel unreachable at that moment came back with the 24 h `down-after` and no automatic
  failover until the next config re-render. Each unit now re-checks its own sentinel on
  `update-status` (outside a restore) and resets it.
- **refactor(restore): log the restore trail** — `restore.*` log lines for every action
  rejection, step, barrier advance, completion, download, rollback and failure
  (`juju debug-log | grep restore.` shows the whole run); the failure helpers are renamed
  to say what they do (`_fail_restore` / `_finish_failed_restore`); comment/nit cleanups.
- **refactor(cluster): fuse the bounded waits** — `_wait_until(condition, timeout, failure)`
  replaces the duplicated tenacity loops in `wait_until_loaded` / `wait_until_resynced`.
- **test(restore): single-unit happy path** — `test_restore_single_unit` (1-unit app:
  leader == primary, no resync, cascade driven only by the leader's own app-databag
  relation-changed); also asserts the unit is writable after the restart.

No databag/schema changes; behaviour change is limited to the sentinel self-heal.