### PR TITLE
chore: add logging configuration for jubilant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+log_cli_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
+log_cli_date_format = "%Y-%m-%dT%H:%M:%SZ"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 


### PR DESCRIPTION
With the recent update to Jubilant in #94, the default log output of Jubilant has changed. In order to still be able to follow integration tests properly, this PR adds logging configuration for Jubilant and adds the timestamp to the log output.

Example:
```
2026-08-19T10:29:33Z INFO jubilant.wait [valkey/1] status changed: maintenance (Waiting for leader to allow service start) -> active ()
2026-08-19T10:30:39Z INFO jubilant.wait [valkey/2] status changed: maintenance (Waiting for leader to allow service start) -> active ()
```