### PR TITLE
[DPE-10892] Add scripting and caching permissions

### DIFF
--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -122,6 +122,11 @@ class AuthManager(ManagerStatusProtocol):
         Returns:
             str: ACL lines for the external client users.
         """
+        valkey_base_permissions = (
+            "-@all +@read +@write +@keyspace +@pubsub +@transaction +info +ping +role "
+        )
+        valkey_scripting_permissions = ""
+        valkey_client_caching_permissions = "+client|id +client|tracking "
         sentinel_base_permissions = "-@all +auth +client +command +hello +ping +role "
         sentinel_sentinel_permissions = "+sentinel|get-master-addr-by-name +sentinel|master +sentinel|masters +sentinel|replicas +sentinel|sentinels"
         acl_content = ""
@@ -130,7 +135,13 @@ class AuthManager(ManagerStatusProtocol):
             return acl_content
 
         for username, values in external_client_users.items():
-            permissions = f"-@all +@read +@write +@keyspace +@pubsub +@transaction +info +ping +role ~{values['resource']} &{values['resource']}"
+            user_specific_permissions = f"~{values['resource']} &{values['resource']}"
+            permissions = (
+                valkey_base_permissions
+                + valkey_client_caching_permissions
+                + valkey_scripting_permissions
+                + user_specific_permissions
+            )
             if for_sentinel:
                 permissions = sentinel_base_permissions + sentinel_sentinel_permissions
             password_hash = hashlib.sha256(values["password"].encode("utf-8")).hexdigest()

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -123,7 +123,7 @@ class AuthManager(ManagerStatusProtocol):
             str: ACL lines for the external client users.
         """
         valkey_base_permissions = (
-            "-@all +@read +@write +@keyspace +@pubsub +@transaction +info +ping +role "
+            "-@all +@read +@write +@keyspace -migrate +@pubsub +@transaction +info +ping +role "
         )
         valkey_scripting_permissions = "+eval +evalsha +@scripting "
         valkey_client_caching_permissions = "+client|id +client|tracking "

--- a/src/managers/auth.py
+++ b/src/managers/auth.py
@@ -125,7 +125,7 @@ class AuthManager(ManagerStatusProtocol):
         valkey_base_permissions = (
             "-@all +@read +@write +@keyspace +@pubsub +@transaction +info +ping +role "
         )
-        valkey_scripting_permissions = ""
+        valkey_scripting_permissions = "+eval +evalsha +@scripting "
         valkey_client_caching_permissions = "+client|id +client|tracking "
         sentinel_base_permissions = "-@all +auth +client +command +hello +ping +role "
         sentinel_sentinel_permissions = "+sentinel|get-master-addr-by-name +sentinel|master +sentinel|masters +sentinel|replicas +sentinel|sentinels"

--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -119,6 +119,9 @@ class ConfigManager(ManagerStatusProtocol):
         ldap_config = self.generate_ldap_config()
         config_properties.update(ldap_config)
 
+        # Client-side caching: limit memory consumption for key-invalidation table
+        config_properties["tracking-table-max-keys"] = "1000000"
+
         return config_properties
 
     def _generate_replica_config(self, primary_endpoint: str) -> dict[str, str]:


### PR DESCRIPTION
This PR addresses:
- #82
- #88 

The permissions for external client users are adjusted to allow client-side caching and LUA scripting. To safeguard memory consumption for client-side caching, the configuration `tracking-table-max-keys` is explicitly set to 1M (same as default).

Regarding scripting: The scripting permissions do not impact the keyspace permissions, or in other words: Scripts can only be executed on a key if the user has permissions for it. This was confirmed by testing:
```
$ juju deploy data-integrator
$ juju deploy ./valkey_ubuntu@24.04-amd64.charm --trust --resource valkey-image=ghcr.io/canonical/charmed-valkey:9.0.1-26.04_edge
$ juju config data-integrator prefix-name="test:*"
$ juju integrate data-integrator valkey                                                                             
$ valkey-cli -h 10.1.0.12 -p 6379
10.1.0.12:6379> auth relation-5-ee6157ff1cd25188 <password>
OK                                                                
10.1.0.12:6379> set mykey 42
(error) NOPERM No permissions to access a key
10.1.0.12:6379> set test:mykey 42
OK
10.1.0.12:6379> get mykey
(error) NOPERM No permissions to access a key
10.1.0.12:6379> get test:mykey
"42"
10.1.0.12:6379> EVAL "return server.call('SET', KEYS[1], ARGV[1])" 1 foo bar
(error) NOPERM No permissions to access a key
10.1.0.12:6379> EVAL "return server.call('SET', KEYS[1], ARGV[1])" 1 test:foo bar
OK
10.1.0.12:6379> EVAL "return server.call('GET', KEYS[1])" 1 foo
(error) NOPERM No permissions to access a key
10.1.0.12:6379> EVAL "return server.call('GET', KEYS[1])" 1 test:foo
"bar"
```

Integration test failures for storage reuse on VM are addressed in #102 