### PR TITLE
[DPE-10894] Improve scale-down procedure

### DIFF
--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -56,6 +56,14 @@ class ValkeyServicesCouldNotBeStoppedError(Exception):
     """Custom Exception if Valkey services could not be stopped."""
 
 
+class CannotSeeAllActiveSentinelsError(Exception):
+    """Custom Exception if the local sentinel cannot see all active sentinels in the cluster."""
+
+
+class SentinelIncorrectReplicaCountError(Exception):
+    """Custom Exception if the sentinel sees an incorrect number of replicas."""
+
+
 class RequestingLockTimedOutError(Exception):
     """Custom Exception if requesting a lock times out."""
 

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -64,6 +64,10 @@ class SentinelIncorrectReplicaCountError(Exception):
     """Custom Exception if the sentinel sees an incorrect number of replicas."""
 
 
+class NotAllDepartingSentinelsStoppedError(Exception):
+    """Custom Exception if not all departing Sentinels have already been stopped."""
+
+
 class RequestingLockTimedOutError(Exception):
     """Custom Exception if requesting a lock times out."""
 

--- a/src/common/exceptions.py
+++ b/src/common/exceptions.py
@@ -56,14 +56,6 @@ class ValkeyServicesCouldNotBeStoppedError(Exception):
     """Custom Exception if Valkey services could not be stopped."""
 
 
-class CannotSeeAllActiveSentinelsError(Exception):
-    """Custom Exception if the local sentinel cannot see all active sentinels in the cluster."""
-
-
-class SentinelIncorrectReplicaCountError(Exception):
-    """Custom Exception if the sentinel sees an incorrect number of replicas."""
-
-
 class RequestingLockTimedOutError(Exception):
     """Custom Exception if requesting a lock times out."""
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -139,6 +139,7 @@ class PeerAppModel(PeerModel):
     restore_token: str = Field(default="")
     restore_instruction: str = Field(default="")
     restore_participants: str = Field(default="")
+    sentinel_reset_required: bool = Field(default=False)
 
 
 class PeerUnitModel(PeerModel):

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -708,7 +708,7 @@ class BaseEvents(ops.Object):
             if ip != self.charm.state.unit_server.get_endpoint(self.charm.state.substrate)
         ]
 
-        if active_sentinels:
+        if active_sentinels and self.charm.app.planned_units() != 0:
             logger.debug("Resetting sentinel states on active units: %s", active_sentinels)
             self.charm.sentinel_manager.reset_sentinel_states(active_sentinels)
 

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -11,7 +11,10 @@ import ops
 
 from common.custom_events import UnitFullyStartedEvent
 from common.exceptions import (
+    CannotSeeAllActiveSentinelsError,
+    NotAllDepartingSentinelsStoppedError,
     RequestingLockTimedOutError,
+    SentinelIncorrectReplicaCountError,
     ValkeyACLLoadError,
     ValkeyBackupInProgressError,
     ValkeyCannotGetPrimaryIPError,
@@ -255,7 +258,7 @@ class BaseEvents(ops.Object):
         except (ValkeyWorkloadCommandError, ValueError) as e:
             logger.error("Failed to start topology observer: %s", e)
 
-    def _on_peer_relation_changed(self, _: ops.RelationChangedEvent) -> None:
+    def _on_peer_relation_changed(self, event: ops.RelationChangedEvent) -> None:
         """Handle event received by all units when a unit's relation data changes."""
         if self.charm.state.cluster.is_restore_in_progress:
             return
@@ -277,6 +280,19 @@ class BaseEvents(ops.Object):
             lock.process()
 
         if not self.charm.state.unit_server.is_active:
+            return
+
+        try:
+            self.charm.sentinel_manager.remove_departed_sentinels_from_cluster()
+        except (
+            CannotSeeAllActiveSentinelsError,
+            NotAllDepartingSentinelsStoppedError,
+            SentinelIncorrectReplicaCountError,
+            ValkeyCannotGetPrimaryIPError,
+            ValkeyWorkloadCommandError,
+        ) as e:
+            logger.error(e)
+            event.defer()
             return
 
         # return early during TLS switchover to avoid unnecessary operation during rolling restart for sentinel
@@ -309,7 +325,13 @@ class BaseEvents(ops.Object):
         if self.charm.state.unit_server.is_started:
             self.charm.cluster_manager.reconcile_min_replicas_to_write()
 
-        if not self.charm.unit.is_leader() or not self.charm.state.unit_server.is_active:
+        if not self.charm.unit.is_leader():
+            return
+
+        # trigger Sentinel reset and health check, executed on relation-changed
+        self.charm.state.cluster.update({"sentinel_reset_required": True})
+
+        if not self.charm.state.unit_server.is_active:
             return
 
         try:
@@ -354,6 +376,19 @@ class BaseEvents(ops.Object):
             return
 
         if self.charm.state.unit_server.is_active:
+            try:
+                self.charm.sentinel_manager.remove_departed_sentinels_from_cluster()
+            except (
+                CannotSeeAllActiveSentinelsError,
+                NotAllDepartingSentinelsStoppedError,
+                SentinelIncorrectReplicaCountError,
+                ValkeyCannotGetPrimaryIPError,
+                ValkeyWorkloadCommandError,
+            ) as e:
+                logger.error(e)
+                event.defer()
+                return
+
             try:
                 self.charm.topology_manager.start_observer()
             except (ValkeyWorkloadCommandError, ValueError) as e:
@@ -654,7 +689,6 @@ class BaseEvents(ops.Object):
             scope="unit",
             component=self.charm.cluster_manager.name,
         )
-        # TODO consider quorum when removing unit
 
         self.charm.status.set_running_status(
             ScaleDownStatuses.SCALING_DOWN.value,
@@ -662,6 +696,7 @@ class BaseEvents(ops.Object):
             component_name=self.charm.cluster_manager.name,
             statuses_state=self.charm.state.statuses,
         )
+
         # if unit has primary then failover
         try:
             primary_ip = self.charm.sentinel_manager.get_primary_ip_for_scale_down()
@@ -691,9 +726,8 @@ class BaseEvents(ops.Object):
             logger.info("Waiting for replica to be fully-synced before saving the dataset")
             self.charm.cluster_manager.wait_for_replica_fully_synced(primary_ip)
 
+        # stop valkey
         self.charm.cluster_manager.save_dataset_before_shutdown()
-
-        # stop valkey and sentinel processes
         try:
             self.charm.workload.stop()
         except ValkeyServicesCouldNotBeStoppedError as e:
@@ -701,21 +735,7 @@ class BaseEvents(ops.Object):
 
         self.charm.state.unit_server.update({"start_state": StartState.NOT_STARTED.value})
 
-        # reset sentinel states on other units
-        active_sentinels = [
-            ip
-            for ip in active_sentinels
-            if ip != self.charm.state.unit_server.get_endpoint(self.charm.state.substrate)
-        ]
-
-        if active_sentinels and self.charm.app.planned_units() != 0:
-            logger.debug("Resetting sentinel states on active units: %s", active_sentinels)
-            self.charm.sentinel_manager.reset_sentinel_states(active_sentinels)
-
-            # check health after scale down
-            self.charm.sentinel_manager.verify_expected_replica_count(active_sentinels)
-
-        if active_sentinels:
+        if len(active_sentinels) > 1:
             scale_down_lock.release_lock(primary_ip=primary_ip)
 
         self._set_state_for_going_away()

--- a/src/events/base_events.py
+++ b/src/events/base_events.py
@@ -714,7 +714,8 @@ class BaseEvents(ops.Object):
 
             # check health after scale down
             self.charm.sentinel_manager.verify_expected_replica_count(active_sentinels)
-            # release lock
+
+        if active_sentinels:
             scale_down_lock.release_lock(primary_ip=primary_ip)
 
         self._set_state_for_going_away()

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -14,7 +14,9 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 
 from common.client import SentinelClient
 from common.exceptions import (
+    CannotSeeAllActiveSentinelsError,
     SentinelFailoverError,
+    SentinelIncorrectReplicaCountError,
     ValkeyCannotGetPrimaryIPError,
     ValkeyWorkloadCommandError,
 )
@@ -236,6 +238,9 @@ class SentinelManager(ManagerStatusProtocol):
                 logger.warning(
                     "Sentinel at %s does not see all other sentinels after reset.", sentinel_ip
                 )
+                raise CannotSeeAllActiveSentinelsError(
+                    "Sentinel at %s does not see all other sentinels after reset." % sentinel_ip
+                )
 
     @retry(
         wait=wait_fixed(5),
@@ -315,6 +320,12 @@ class SentinelManager(ManagerStatusProtocol):
                 number_replicas := len(client.replicas_primary(hostname=sentinel_ip))
             ):
                 logger.warning(
+                    "Sentinel at %s sees %d replicas, expected %d.",
+                    sentinel_ip,
+                    number_replicas,
+                    expected_replicas,
+                )
+                raise SentinelIncorrectReplicaCountError(
                     "Sentinel at %s sees %d replicas, expected %d.",
                     sentinel_ip,
                     number_replicas,

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -15,6 +15,7 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 from common.client import SentinelClient
 from common.exceptions import (
     CannotSeeAllActiveSentinelsError,
+    NotAllDepartingSentinelsStoppedError,
     SentinelFailoverError,
     SentinelIncorrectReplicaCountError,
     ValkeyCannotGetPrimaryIPError,
@@ -35,7 +36,7 @@ from literals import (
     K8sService,
     Substrate,
 )
-from statuses import CharmStatuses
+from statuses import CharmStatuses, ScaleDownStatuses
 
 logger = logging.getLogger(__name__)
 
@@ -202,6 +203,11 @@ class SentinelManager(ManagerStatusProtocol):
 
         return True
 
+    def is_sentinel_active(self, sentinel_ip: str) -> bool:
+        """Check if the sentinel is active and responds to a ping."""
+        client = self._get_sentinel_client()
+        return client.ping(hostname=sentinel_ip)
+
     def failover(self) -> None:
         """Trigger a failover in the cluster.
 
@@ -218,6 +224,34 @@ class SentinelManager(ManagerStatusProtocol):
         except ValkeyWorkloadCommandError as e:
             logger.error("Failed to trigger failover: %s", e)
             raise SentinelFailoverError from e
+
+    def remove_departed_sentinels_from_cluster(self) -> None:
+        """Ensure departed units get removed from the Sentinel cluster.
+
+        Raises:
+            ValkeyCannotGetPrimaryIPError: If fails to query primary
+            ValkeyWorkloadCommandError: If any client command fails
+            NotAllDepartingSentinelsStoppedError: If a departing unit has not yet stopped its Sentinel
+            CannotSeeAllActiveSentinelsError: If any Sentinel does not see all other Sentinels
+            SentinelIncorrectReplicaCountError: If any sentinel sees an incorrect number of replicas
+        """
+        if not self.state.cluster.model.sentinel_reset_required:
+            return
+
+        logger.info("Resetting Sentinels after unit removal")
+        primary_ip = self.get_primary_ip()
+        active_sentinels = self.get_active_sentinel_ips(primary_ip)
+
+        if len(active_sentinels) != self.state.model.app.planned_units():
+            raise NotAllDepartingSentinelsStoppedError(
+                "Cluster should have %s units, but %s Sentinels are active",
+                self.state.model.app.planned_units(),
+                len(active_sentinels),
+            )
+
+        self.reset_sentinel_states(active_sentinels)
+        self.verify_expected_replica_count(active_sentinels)
+        self.state.cluster.update({"sentinel_reset_required": False})
 
     def reset_sentinel_states(self, sentinel_ips: list[str]) -> None:
         """Reset the sentinel states on all sentinels in the cluster.
@@ -346,9 +380,16 @@ class SentinelManager(ManagerStatusProtocol):
         """
         client = self._get_sentinel_client()
 
-        return [hostname] + [
+        all_sentinels = [hostname] + [
             sentinel["ip"] for sentinel in client.sentinels_primary(hostname=hostname)
         ]
+
+        active_sentinels = []
+        for sentinel in all_sentinels:
+            if self.is_sentinel_active(sentinel):
+                active_sentinels.append(sentinel)
+
+        return active_sentinels
 
     def restart_service(self) -> None:
         """Restart the sentinel service to load configuration."""
@@ -449,6 +490,17 @@ class SentinelManager(ManagerStatusProtocol):
         status_list: list[StatusObject] = self.state.statuses.get(
             scope=scope, component=self.name, running_status_only=True, running_status_type="async"
         ).root
+
+        # Peer relation not established yet or model not built yet
+        if not self.state.cluster.model:
+            return status_list or [CharmStatuses.ACTIVE_IDLE.value]
+
+        if (
+            scope == "app"
+            and self.state.cluster.model.sentinel_reset_required
+            and self.state.model.app.planned_units() != 0
+        ):
+            status_list.append(ScaleDownStatuses.SENTINEL_NOT_REMOVED_AFTER_SCALEDOWN.value)
 
         return status_list or [CharmStatuses.ACTIVE_IDLE.value]
 

--- a/src/managers/sentinel.py
+++ b/src/managers/sentinel.py
@@ -14,9 +14,7 @@ from tenacity import retry, retry_if_result, stop_after_attempt, wait_fixed
 
 from common.client import SentinelClient
 from common.exceptions import (
-    CannotSeeAllActiveSentinelsError,
     SentinelFailoverError,
-    SentinelIncorrectReplicaCountError,
     ValkeyCannotGetPrimaryIPError,
     ValkeyWorkloadCommandError,
 )
@@ -238,9 +236,6 @@ class SentinelManager(ManagerStatusProtocol):
                 logger.warning(
                     "Sentinel at %s does not see all other sentinels after reset.", sentinel_ip
                 )
-                raise CannotSeeAllActiveSentinelsError(
-                    "Sentinel at %s does not see all other sentinels after reset." % sentinel_ip
-                )
 
     @retry(
         wait=wait_fixed(5),
@@ -320,12 +315,6 @@ class SentinelManager(ManagerStatusProtocol):
                 number_replicas := len(client.replicas_primary(hostname=sentinel_ip))
             ):
                 logger.warning(
-                    "Sentinel at %s sees %d replicas, expected %d.",
-                    sentinel_ip,
-                    number_replicas,
-                    expected_replicas,
-                )
-                raise SentinelIncorrectReplicaCountError(
                     "Sentinel at %s sees %d replicas, expected %d.",
                     sentinel_ip,
                     number_replicas,

--- a/src/statuses.py
+++ b/src/statuses.py
@@ -101,6 +101,10 @@ class ScaleDownStatuses(Enum):
         status="maintenance",
         message="Waiting for juju to remove the unit...",
     )
+    SENTINEL_NOT_REMOVED_AFTER_SCALEDOWN = StatusObject(
+        status="maintenance",
+        message="Not all Sentinels removed after scale down",
+    )
 
 
 class TLSStatuses(Enum):

--- a/tests/unit/test_min_replicas_reconcile.py
+++ b/tests/unit/test_min_replicas_reconcile.py
@@ -60,6 +60,8 @@ def test_peer_relation_departed_reconciles_min_replicas(cloud_spec):
         patch("common.client.SentinelClient.primary", return_value={"quorum": "2"}),
         patch("common.client.SentinelClient.set"),
         patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.0.1"),
+        patch("managers.sentinel.SentinelManager.get_active_sentinel_ips"),
+        patch("managers.sentinel.SentinelManager.verify_expected_replica_count"),
         patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write") as mock_reconcile,
     ):
         ctx.run(ctx.on.relation_departed(relation, remote_unit=2), state_in)

--- a/tests/unit/test_min_replicas_reconcile.py
+++ b/tests/unit/test_min_replicas_reconcile.py
@@ -61,7 +61,6 @@ def test_peer_relation_departed_reconciles_min_replicas(cloud_spec):
         patch("common.client.SentinelClient.set"),
         patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="127.1.0.1"),
         patch("managers.sentinel.SentinelManager.get_active_sentinel_ips"),
-        patch("managers.sentinel.SentinelManager.verify_expected_replica_count"),
         patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write") as mock_reconcile,
     ):
         ctx.run(ctx.on.relation_departed(relation, remote_unit=2), state_in)

--- a/tests/unit/test_scaledown.py
+++ b/tests/unit/test_scaledown.py
@@ -9,7 +9,7 @@ from ops import testing
 
 from charm import ValkeyCharm
 from common.exceptions import ValkeyCannotGetPrimaryIPError, ValkeyWorkloadCommandError
-from literals import CONTAINER, PEER_RELATION, ScaleDownState
+from literals import CONTAINER, PEER_RELATION, STATUS_PEERS_RELATION, ScaleDownState
 from statuses import ScaleDownStatuses
 from tests.unit.helpers import status_is
 
@@ -97,17 +97,12 @@ def test_non_primary(cloud_spec):
             "common.client.SentinelClient.sentinels_primary",
             side_effect=[
                 [{"ip": "valkey-0"}, {"ip": "valkey-2"}],  # for get_active_sentinel_ips
-                [{"ip": "valkey-2"}],  # for target_sees_all_others unit valkey-1
-                [{"ip": "valkey-1"}],  # for target_sees_all_others unit valkey-2
             ],
         ),
-        patch(
-            "common.client.SentinelClient.replicas_primary", return_value=[{"ip": "ip"}]
-        ),  # we need the len to be 1
     ):
         state_out = ctx.run(ctx.on.storage_detaching(data_strorage), state_in)
         mock_stop.assert_called_once()
-        assert mock_reset.call_count == 2
+        mock_reset.assert_not_called()
         assert get_replica_offset.call_count == 2
         save_dataset.assert_called_once()
         status_is(state_out, ScaleDownStatuses.GOING_AWAY.value)
@@ -153,17 +148,12 @@ def test_non_primary_block_until_synced(cloud_spec):
             "common.client.SentinelClient.sentinels_primary",
             side_effect=[
                 [{"ip": "valkey-0"}, {"ip": "valkey-2"}],  # for get_active_sentinel_ips
-                [{"ip": "valkey-2"}],  # for target_sees_all_others unit valkey-1
-                [{"ip": "valkey-1"}],  # for target_sees_all_others unit valkey-2
             ],
         ),
-        patch(
-            "common.client.SentinelClient.replicas_primary", return_value=[{"ip": "ip"}]
-        ),  # we need the len to be 1
     ):
         state_out = ctx.run(ctx.on.storage_detaching(data_strorage), state_in)
         mock_stop.assert_called_once()
-        assert mock_reset.call_count == 2
+        mock_reset.assert_not_called()
         assert get_replica_offset.call_count == 3
         save_dataset.assert_called_once()
         status_is(state_out, ScaleDownStatuses.GOING_AWAY.value)
@@ -203,23 +193,18 @@ def test_primary(cloud_spec):
             "common.client.SentinelClient.sentinels_primary",
             side_effect=[
                 [{"ip": "10.0.1.1"}, {"ip": "10.0.1.2"}],  # for get_active_sentinel_ips
-                [],  # for target_sees_all_others unit 10.0.1.1 not yet
-                ValkeyWorkloadCommandError(
-                    "errored out"
-                ),  # for target_sees_all_others unit 10.0.1.1 network mishap
-                [{"ip": "10.0.1.2"}],  # for target_sees_all_others unit 10.0.1.1
-                [{"ip": "10.0.1.1"}],  # for target_sees_all_others unit 10.0.1.2
             ],
         ),
         patch(
-            "common.client.SentinelClient.replicas_primary", return_value=[{"ip": "ip"}]
-        ),  # we need the len to be 1
+            "common.client.SentinelClient.ping",
+            side_effect=[True, False, True],  # valkey-1 is no longer active
+        ),
     ):
         state_out = ctx.run(ctx.on.storage_detaching(data_strorage), state_in)
         mock_failover.assert_called_once()
         mock_failover_in_progress.assert_called_once()
         mock_stop.assert_called_once()
-        assert mock_reset.call_count == 2
+        mock_reset.assert_not_called()
         get_replica_offset.assert_not_called()
         save_dataset.assert_called_once()
         status_is(state_out, ScaleDownStatuses.GOING_AWAY.value)
@@ -381,4 +366,235 @@ def test_cannot_get_primary_ip_leader(cloud_spec):
         status_is(state_out, ScaleDownStatuses.GOING_AWAY.value)
         cluster_update.assert_called_once_with(
             {"internal_ca_certificate": None, "internal_ca_private_key": None}
+        )
+
+
+def test_unit_departure_sentinel_reset_flag(cloud_spec):
+    """Test that the flag for removing Sentinels is set on peer-relation-departed."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_unit_data={
+            "hostname": "valkey-0",
+            "private-ip": "10.0.1.0",
+            "start-state": "started",
+        },
+        peers_data={
+            1: {
+                "hostname": "valkey-2",
+                "private-ip": "10.0.1.2",
+                "start-state": "started",
+            }
+        },
+    )
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation},
+        leader=True,
+        planned_units=2,
+        containers={container},
+    )
+    state_out = ctx.run(ctx.on.relation_departed(relation, remote_unit=2), state_in)
+    assert state_out.get_relation(1).local_app_data.get("sentinel-reset-required") == "true"
+
+
+def test_unit_departure_leader(cloud_spec):
+    """Test Sentinel removal after scale down."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"sentinel-reset-required": "True"},
+        local_unit_data={
+            "hostname": "valkey-0",
+            "private-ip": "10.0.1.0",
+            "start-state": "started",
+        },
+        peers_data={
+            1: {
+                "hostname": "valkey-2",
+                "private-ip": "10.0.1.2",
+                "start-state": "started",
+            }
+        },
+    )
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation, status_peer_relation},
+        leader=True,
+        planned_units=2,
+        containers={container},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="valkey-0"),
+        patch("events.base_events.BaseEvents._reconfigure_quorum_if_necessary"),
+        patch("managers.cluster.ClusterManager.reconcile_min_replicas_to_write"),
+        patch(
+            "common.client.SentinelClient.sentinels_primary",
+            side_effect=[
+                [{"ip": "valkey-1"}, {"ip": "valkey-2"}],  # for get_active_sentinel_ips
+                [{"ip": "valkey-2"}],  # for target_sees_all_others unit valkey-0
+                [{"ip": "valkey-0"}],  # for target_sees_all_others unit valkey-2
+            ],
+        ),
+        patch(
+            "common.client.SentinelClient.ping",
+            side_effect=[True, False, True],  # valkey-1 is no longer active
+        ),
+        patch("common.client.SentinelClient.reset"),
+        patch(
+            "common.client.SentinelClient.replicas_primary",
+            side_effect=[{"ip": "ip"}, {"ip": "ip"}],
+        ),
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation, remote_unit=2), state_in)
+        assert state_out.get_relation(1).local_app_data.get("sentinel-reset-required") == "false"
+
+
+def test_unit_departure_not_yet_removed(cloud_spec):
+    """Test scale-down behavior when this unit is the primary and successfully acquires the lock."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"sentinel-reset-required": "True"},
+        local_unit_data={
+            "hostname": "valkey-0",
+            "private-ip": "10.0.1.0",
+            "start-state": "started",
+        },
+        peers_data={
+            1: {
+                "hostname": "valkey-2",
+                "private-ip": "10.0.1.2",
+                "start-state": "started",
+            }
+        },
+    )
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation, status_peer_relation},
+        leader=True,
+        planned_units=2,
+        containers={container},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="valkey-0"),
+        patch(
+            "common.client.SentinelClient.sentinels_primary",
+            side_effect=[
+                [{"ip": "valkey-1"}, {"ip": "valkey-2"}],  # for get_active_sentinel_ips
+            ],
+        ),
+        patch(
+            "common.client.SentinelClient.ping",
+            side_effect=[True, True, True],  # valkey-1 is still active
+        ),
+        patch("common.client.SentinelClient.replicas_primary") as verify,
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation, remote_unit=2), state_in)
+        verify.assert_not_called()
+        assert "valkey_peers_relation_changed" in [e.name for e in state_out.deferred]
+        assert state_out.get_relation(1).local_app_data.get("sentinel-reset-required") == "true"
+        assert status_is(
+            state_out, ScaleDownStatuses.SENTINEL_NOT_REMOVED_AFTER_SCALEDOWN.value, is_app=True
+        )
+
+
+def test_unit_departure_leader_failed(cloud_spec):
+    """Test scale-down behavior when this unit is the primary and successfully acquires the lock."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = testing.PeerRelation(
+        id=1,
+        endpoint=PEER_RELATION,
+        local_app_data={"sentinel-reset-required": "True"},
+        local_unit_data={
+            "hostname": "valkey-0",
+            "private-ip": "10.0.1.0",
+            "start-state": "started",
+        },
+        peers_data={
+            1: {
+                "hostname": "valkey-2",
+                "private-ip": "10.0.1.2",
+                "start-state": "started",
+            }
+        },
+    )
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation, status_peer_relation},
+        leader=True,
+        planned_units=2,
+        containers={container},
+    )
+
+    with (
+        patch(
+            "core.cluster_state.ClusterState.bind_address",
+            new_callable=PropertyMock(return_value="10.0.1.0"),
+        ),
+        patch("managers.sentinel.SentinelManager.get_primary_ip", return_value="valkey-0"),
+        patch(
+            "common.client.SentinelClient.sentinels_primary",
+            side_effect=[
+                [{"ip": "valkey-2"}],  # for get_active_sentinel_ips
+                [{"ip": "valkey-2"}],  # for target_sees_all_others unit valkey-0
+                [{"ip": "valkey-0"}, {"ip": "valkey-1"}],  # valkey-2 still sees valkey-1
+            ],
+        ),
+        patch(
+            "common.client.SentinelClient.ping",
+            side_effect=[True, False, True],  # valkey-1 is no longer active
+        ),
+        patch("common.client.SentinelClient.reset"),
+        patch(
+            "common.client.SentinelClient.replicas_primary",
+            side_effect=[{"ip": "ip"}, {"another_ip": "another_ip"}],
+        ),
+    ):
+        state_out = ctx.run(ctx.on.relation_changed(relation, remote_unit=2), state_in)
+        assert state_out.get_relation(1).local_app_data.get("sentinel-reset-required") == "true"
+        assert "valkey_peers_relation_changed" in [e.name for e in state_out.deferred]
+        assert status_is(
+            state_out, ScaleDownStatuses.SENTINEL_NOT_REMOVED_AFTER_SCALEDOWN.value, is_app=True
+        )
+
+
+def test_unit_departure_non_leader(cloud_spec):
+    """Test scale-down behavior when this unit is the primary and successfully acquires the lock."""
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    relation = get_3_unit_peer_relation()
+    status_peer_relation = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
+    container = testing.Container(name=CONTAINER, can_connect=True)
+    state_in = testing.State(
+        model=testing.Model(name="my-vm-model", type="lxd", cloud_spec=cloud_spec),
+        relations={relation, status_peer_relation},
+        leader=False,
+        containers={container},
+    )
+
+    with patch("managers.sentinel.SentinelManager.verify_expected_replica_count") as verify:
+        state_out = ctx.run(ctx.on.relation_changed(relation, remote_unit=2), state_in)
+        verify.assert_not_called()
+        assert not status_is(
+            state_out, ScaleDownStatuses.SENTINEL_NOT_REMOVED_AFTER_SCALEDOWN.value, is_app=True
         )


### PR DESCRIPTION
This PR attempts to improve the stability of scaling down / removing the application.

As seen in multiple CI runs ([example 1](https://github.com/canonical/valkey-operator/actions/runs/32492483752/job/97336924041?pr=101#step:13:28025), [example 2](https://github.com/canonical/valkey-operator/actions/runs/32610038957/job/97337902711#step:13:28909)), the removal of the entire application may take unusually long and never complete. This needs improvement to avoid users not being able to remove a Valkey cluster, or being tempted to run removal with `--force`.

The cause for this issue is that if the connection to the other units is not possible, an exception is raised from the charm because of Sentinel health check errors. This exception occurs _after_ the workload on this unit has already been stopped. If the event handler returns, earlier checks/actions on the `storage_detaching` event are bound to fail, resulting in a never-healing error.

The proposed solution is to decouple unit removal and Sentinel removal. The goal is to not have any operation _after_ the actual workload stop that could raise. Once stopped, the `storage_detaching` hook should not fail anymore.  

The proposed design:
- the responsibility for Sentinel removal/reset and health check is now at the Sentinel Manager, the `storage_detaching` hook of the departing unit does not care about Sentinel state anymore
- the leader unit sets a flag `sentinel_reset_required` to the application databag on `peer-relation-departed`
- the leader unit checks on `peer-relation-changed` if one or more Sentinels need to be removed from the cluster and executes the removal and the health checks on all remaining Sentinels
- the Sentinel removal must only happen after the Sentinel service on the departing unit was stopped
- multiple departing Sentinels are collected and only once all are stopped, the removal is executed
- the workflow is save for Juju leadership changes during removal (ensured through `leader-elected`)
- if the removal of departed Sentinels was not successful, a status message is displayed