### PR TITLE
drop the protobuf and rustup installs left over from the valkey-glide fork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,11 +36,6 @@ jobs:
         run: |
           pipx install tox
           pipx install poetry
-      # to build Valkey-glide during tests
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libprotobuf-dev protobuf-compiler
       - name: Run tests
         run: tox run -e unit
       - name: Upload Coverage to Codecov
@@ -57,11 +52,6 @@ jobs:
         run: |
           pipx install tox
           pipx install poetry
-      # to build Valkey-glide during tests (matches unit-test job)
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libprotobuf-dev protobuf-compiler
       - name: Run pyright
         run: tox run -e static
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -33,16 +33,10 @@ jobs:
             done
             return 1
           }
-          sudo apt update
           retry sudo snap install charmcraft --classic
           retry sudo snap install go --classic
           go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
-          # to build Valkey-glide during tests
-          sudo apt install libprotobuf-dev protobuf-compiler -y
-          sudo apt install rustup -y
-          rustup set profile minimal
-          rustup default 1.90.0
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
@@ -159,15 +153,9 @@ jobs:
             done
             return 1
           }
-          sudo apt update
           retry sudo snap install charmcraft --classic
           retry sudo snap install go --classic
           go install github.com/canonical/spread/cmd/spread@latest
-          # to build Valkey-glide during tests
-          sudo apt install libprotobuf-dev protobuf-compiler -y
-          sudo apt install rustup -y
-          rustup set profile minimal
-          rustup default 1.90.0
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v6

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -68,8 +68,6 @@ parts:
       - libffi-dev # Needed to build Python dependencies with Rust from source
       - libssl-dev # Needed to build Python dependencies with Rust from source
       - pkg-config # Needed to build Python dependencies with Rust from source
-      - libprotobuf-dev # Needed to build Valkey-glide
-      - protobuf-compiler # Needed to build Valkey-glide
     override-build: |
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source

--- a/spread.yaml
+++ b/spread.yaml
@@ -185,7 +185,6 @@ prepare: |
   fi
 
   pipx install tox poetry
-  rustup default 1.90.0
 prepare-each: |
   cd "$SPREAD_PATH"
   # `concierge prepare` needs to be run for each spread job in case Juju version changed

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -12,8 +12,8 @@ file so that Claude Code and Gemini CLI pick it up too.)
   continuous writes with `valkey-glide` to validate HA scenarios.
 - The integration env's `commands_pre` runs `sudo apt install wget`, downloads a Valkey tarball
   from download.valkey.io, and installs `valkey-cli` into `/usr/local/bin` — all before any
-  controller check. Building the integration dependency group needs
-  `libprotobuf-dev protobuf-compiler` and a Rust toolchain (CI pins 1.90.0).
+  controller check. The integration dependency group installs entirely from PyPI wheels — no
+  protobuf headers or Rust toolchain are needed to build it.
 - When `$CI` is unset, tox runs `juju add-model testing` — a second local run fails if the model
   still exists; `juju destroy-model testing` between runs, or invoke pytest directly from
   `.tox/integration/bin/pytest`.

--- a/tests/integration/clients/requirer-charm/charmcraft.yaml
+++ b/tests/integration/clients/requirer-charm/charmcraft.yaml
@@ -55,8 +55,6 @@ parts:
       - libffi-dev # Needed to build Python dependencies with Rust from source
       - libssl-dev # Needed to build Python dependencies with Rust from source
       - pkg-config # Needed to build Python dependencies with Rust from source
-      - libprotobuf-dev # Needed to build Valkey-glide
-      - protobuf-compiler # Needed to build Valkey-glide
       - git
     build-environment:
       - PIP_BUILD_CONSTRAINT: constraints.txt # Workaround setuptools 82


### PR DESCRIPTION
Follow-up to #98. Now that `valkey-glide` installs as a published wheel, nothing in CI compiles Rust or protobuf any more — but every job still installs the toolchain for it. This removes the dead installs.

No behavioural change to any test; the only reason to look closely is whether something *else* was quietly relying on that toolchain (it isn't — see below).

### What goes

| Where | Removed |
|---|---|
| `ci.yaml` | the whole `Install dependencies` step in **unit-test** and in **static** — `apt update` + `libprotobuf-dev protobuf-compiler` for a package neither dependency group contains |
| `integration_test.yaml` | protobuf, `rustup`, and `rustup default 1.90.0` in both setup steps, plus the `apt update` that fed them (no `apt install` is left in either step) |
| `spread.yaml` | `rustup default 1.90.0` from the global `prepare` |
| `charmcraft.yaml`, `requirer-charm/charmcraft.yaml` | the `libprotobuf-dev` / `protobuf-compiler` build-packages |
| `tests/AGENTS.md` | the line telling contributors they need protobuf headers and a Rust toolchain to build the integration group |
