### PR TITLE
feat(backup): add the Azure Blob backup backend

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -63,6 +63,10 @@ requires:
     interface: s3
     limit: 1
     optional: true
+  azure-credentials:
+    interface: azure_storage
+    limit: 1
+    optional: true
   ldap-ca-cert:
     interface: certificate_transfer
     limit: 1

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,6 +94,47 @@ files = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+description = "Microsoft Azure Core Library for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "integration"]
+files = [
+    {file = "azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d"},
+    {file = "azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+tracing = ["opentelemetry-api (>=1.26,<2.0)"]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+description = "Microsoft Azure Blob Storage Client Library for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "integration"]
+files = [
+    {file = "azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423"},
+    {file = "azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be"},
+]
+
+[package.dependencies]
+azure-core = ">=1.37.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.37.0)"]
+
+[[package]]
 name = "boto3"
 version = "1.43.70"
 description = "The AWS SDK for Python"
@@ -139,7 +180,7 @@ version = "2026.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["integration"]
+groups = ["main", "integration"]
 files = [
     {file = "certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"},
     {file = "certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"},
@@ -328,7 +369,7 @@ version = "3.5.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["integration"]
+groups = ["main", "integration"]
 files = [
     {file = "charset_normalizer-3.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d2478bd3b2ead3962a484fb802891be40d10049fb74f83e09cb4463fad023fea"},
     {file = "charset_normalizer-3.5.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7cdded069549b5eae3d5d9bb6c2e5bb4fe83f9b81863e2a193cd747bf197aebb"},
@@ -922,6 +963,18 @@ groups = ["integration", "unit"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+description = "An ISO 8601 date/time/duration parser and formatter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "integration"]
+files = [
+    {file = "isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15"},
+    {file = "isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6"},
 ]
 
 [[package]]
@@ -1744,7 +1797,7 @@ version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
-groups = ["integration"]
+groups = ["main", "integration"]
 files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
@@ -2226,4 +2279,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "fd4aec1845c5f77a904745083f9db7cf53651ce055f27df26d29ae30ba0fa6e8"
+content-hash = "bfc53964592386d151b9f42da369ae3d657a061896ed2a6bddc08c828f54247a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ ldap3 = ">=2.9.1"
 boto3 = "^1.40"
 mypy-boto3-s3 = "^1.40"
 object-storage-charmlib = "^1.0.0"
+# >=12.15 for StorageStreamDownloader.read(), which the restore path streams through
+azure-storage-blob = "^12.19"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
@@ -73,6 +75,7 @@ valkey-glide = "^2.5"
 kubernetes = "^35.0.0"
 boto3 = "^1.40"
 mypy-boto3-s3 = "^1.40"
+azure-storage-blob = "^12.19"
 
 [tool.coverage.run]
 branch = true

--- a/src/common/storage_backend.py
+++ b/src/common/storage_backend.py
@@ -8,18 +8,23 @@ from __future__ import annotations
 
 import logging
 import pathlib
+from enum import Enum
 from typing import IO, TYPE_CHECKING, BinaryIO, NamedTuple, Protocol, cast
 from urllib.parse import urlparse
 
 import boto3
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
+from azure.storage.blob import BlobServiceClient
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from common.exceptions import StorageBackendError
-from core.models import BackupCredentials, S3Parameters
+from core.models import AzureStorageParameters, BackupCredentials, S3Parameters
+from literals import AZURE_HTTPS_PROTOCOLS
 
 if TYPE_CHECKING:
+    from azure.storage.blob import BlobClient, ContainerClient
     from mypy_boto3_s3.literals import BucketLocationConstraintType
     from mypy_boto3_s3.service_resource import Bucket, S3ServiceResource
 
@@ -83,6 +88,8 @@ def build_backend(params: BackupCredentials, ca_path: pathlib.Path) -> StorageBa
     """
     if isinstance(params, S3Parameters):
         return S3Backend(params, ca_path)
+    if isinstance(params, AzureStorageParameters):
+        return AzureBackend(params)
     raise StorageBackendError(f"No storage backend for {type(params).__name__} credentials")
 
 
@@ -225,3 +232,125 @@ class S3Backend:
             self._bucket().Object(self._key(backup_id)).delete()
         except Exception as e:  # best-effort cleanup
             logger.warning("Failed to delete object %s: %s", self._key(backup_id), e)
+
+
+class AzureBackend:
+    """Azure Blob object store via azure-storage-blob."""
+
+    def __init__(self, params: "AzureStorageParameters"):
+        self.params = params
+
+    @property
+    def location(self) -> str:
+        """Account host, container and prefix -- the audit trail's destination.
+
+        ``hostname``, not the raw URL: an endpoint carrying a SAS token or
+        userinfo must never put credentials into the log.
+        """
+        parsed = urlparse(self._account_url())
+        host = parsed.hostname or self.params.storage_account
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        return f"azure://{host}/{self.params.container}/{self.params.path}"
+
+    def _account_url(self) -> str:
+        """Explicit endpoint (emulator/private) if given, else the derived Blob host."""
+        if self.params.endpoint:
+            return self.params.endpoint
+        scheme = "https" if self.params.connection_protocol in AZURE_HTTPS_PROTOCOLS else "http"
+        return f"{scheme}://{self.params.storage_account}.blob.core.windows.net"
+
+    def _service(self) -> BlobServiceClient:
+        """Build a BlobServiceClient for the configured account.
+
+        The account name is passed explicitly rather than left to the SDK: given a
+        bare key it derives the account from the host's first label, which raises
+        "Unable to determine account name for shared key credential" whenever the
+        endpoint is not ``<account>.blob.*`` -- an emulator or a custom domain,
+        where the account sits in the URL path instead.
+        """
+        return BlobServiceClient(
+            account_url=self._account_url(),
+            credential={
+                "account_name": self.params.storage_account,
+                "account_key": self.params.secret_key,
+            },
+        )
+
+    def _container(self) -> "ContainerClient":
+        return self._service().get_container_client(self.params.container)
+
+    def _blob(self, backup_id: str) -> "BlobClient":
+        return self._container().get_blob_client(self._key(backup_id))
+
+    def _key(self, backup_id: str) -> str:
+        return f"{self.params.path}/{backup_id}"
+
+    @staticmethod
+    def _error_code(exc: HttpResponseError) -> str:
+        """Structured error code of an azure-storage failure ("AuthenticationFailed", ...).
+
+        ``process_storage_error`` attaches the provider's code as a ``StorageErrorCode``
+        -- a ``(str, Enum)`` member whose ``str()`` renders "StorageErrorCode.AUTH..." --
+        so read ``.value`` to get the wire code an action result should show. Absent on
+        transport-level failures the service never answered, hence the default.
+        """
+        code = getattr(exc, "error_code", None) or ""
+        return code.value if isinstance(code, Enum) else str(code)
+
+    def ensure_container(self) -> None:
+        """Create the configured container; tolerates an already-existing one."""
+        try:
+            self._container().create_container()
+        except ResourceExistsError:
+            # Subclass of HttpResponseError, so this clause must stay first.
+            logger.info("Using existing container %s", self.params.container)
+        except HttpResponseError as e:
+            raise StorageBackendError(str(e), safe_code=self._error_code(e)) from e
+
+    def list_object_ids(self) -> list[str]:
+        """Return every blob id stored under the path prefix (auto-paginated)."""
+        prefix = f"{self.params.path}/"
+        try:
+            names = [b.name for b in self._container().list_blobs(name_starts_with=prefix)]
+        except HttpResponseError as e:
+            raise StorageBackendError(str(e), safe_code=self._error_code(e)) from e
+        return [n.removeprefix(prefix) for n in names]
+
+    def head(self, backup_id: str, n: int = 16) -> bytes:
+        """Ranged read of the first ``n`` bytes of the blob for ``backup_id``."""
+        try:
+            return self._blob(backup_id).download_blob(offset=0, length=n).readall()
+        except HttpResponseError as e:
+            raise StorageBackendError(str(e), safe_code=self._error_code(e)) from e
+
+    def upload(self, backup_id: str, reader: IO[bytes]) -> None:
+        """Stream ``reader`` into the blob for ``backup_id`` (sequential block blob).
+
+        ``length=None`` + ``max_concurrency=1``: the source is a non-rewindable
+        pipe from ``valkey-cli --rdb -``, so the SDK must stage blocks
+        sequentially off ``read()`` rather than seek around a known-size stream.
+        """
+        try:
+            self._blob(backup_id).upload_blob(
+                reader, blob_type="BlockBlob", overwrite=True, length=None, max_concurrency=1
+            )
+        except HttpResponseError as e:
+            raise StorageBackendError(str(e), safe_code=self._error_code(e)) from e
+
+    def download(self, backup_id: str) -> RemoteObject:
+        """Open the blob for ``backup_id``; its downloader reads as binary."""
+        try:
+            downloader = self._blob(backup_id).download_blob()
+        except HttpResponseError as e:
+            raise StorageBackendError(str(e), safe_code=self._error_code(e)) from e
+        # The downloader already knows the blob length, so the restore trail gets
+        # its byte count without a second round trip.
+        return RemoteObject(cast(BinaryIO, downloader), downloader.size)
+
+    def delete(self, backup_id: str) -> None:
+        """Delete the blob for ``backup_id``, swallowing any error (best-effort)."""
+        try:
+            self._blob(backup_id).delete_blob()
+        except Exception as e:  # best-effort cleanup
+            logger.warning("Failed to delete blob %s: %s", self._key(backup_id), e)

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -33,6 +33,9 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from literals import (
+    AZURE_HTTP_PROTOCOLS,
+    AZURE_HTTPS_PROTOCOLS,
+    AZURE_REJECTED_PROTOCOLS,
     CLIENTS_USERS_SECRET_LABEL_SUFFIX,
     INTERNAL_CERTS_SECRET_LABEL_SUFFIX,
     INTERNAL_USERS_SECRET_LABEL_SUFFIX,
@@ -117,10 +120,90 @@ class S3Parameters(BaseModel):
         return value
 
 
+class AzureStorageParameters(BaseModel):
+    """Validated, normalised Azure Blob parameters from the azure_storage relation.
+
+    Parses the azure-storage-integrator payload (hyphenated keys) into typed
+    attributes, trimming whitespace and the separators that would corrupt blob
+    key paths, and rejecting a payload missing a required field or whose
+    container/path strip to empty. ``path`` is required at the charm layer even
+    though the lib contract leaves it optional, so listing can never enumerate
+    the whole container. Unknown integrator fields are ignored.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    container: str
+    storage_account: str = Field(alias="storage-account")
+    secret_key: str = Field(alias="secret-key")
+    connection_protocol: str = Field(alias="connection-protocol")
+    path: str
+    endpoint: str | None = None
+    resource_group: str | None = Field(alias="resource-group", default=None)
+
+    @field_validator(
+        "container",
+        "storage_account",
+        "secret_key",
+        "connection_protocol",
+        "path",
+        "endpoint",
+        "resource_group",
+        mode="before",
+    )
+    @classmethod
+    def _strip_whitespace(cls, value: object) -> object:
+        # A copy-pasted key with a trailing newline is common.
+        return value.strip() if isinstance(value, str) else value
+
+    @field_validator("connection_protocol", mode="before")
+    @classmethod
+    def _lowercase_protocol(cls, value: object) -> object:
+        # The protocol is matched against lowercase scheme sets downstream; an
+        # integrator sending "HTTPS" must not fall through to the http branch.
+        return value.lower() if isinstance(value, str) else value
+
+    @field_validator("endpoint")
+    @classmethod
+    def _strip_trailing_slash(cls, value: str | None) -> str | None:
+        # A trailing "/" on the endpoint would double up in the request URL.
+        return value.rstrip("/") if value else value
+
+    @field_validator("container", "path")
+    @classmethod
+    def _strip_surrounding_slashes(cls, value: str) -> str:
+        # Leading/trailing "/" would yield blob names like "//<id>"; stripping
+        # also collapses container="/" or path="/" to "" so _reject_empty catches it.
+        return value.strip("/")
+
+    @field_validator("container", "storage_account", "secret_key", "connection_protocol", "path")
+    @classmethod
+    def _reject_empty(cls, value: str, info: ValidationInfo) -> str:
+        # An empty path makes list_backups enumerate the whole container
+        # (cross-tenant leak in a shared container); reject empties outright.
+        if not value:
+            raise ValueError(f"{info.field_name} must not be empty")
+        return value
+
+    @field_validator("connection_protocol")
+    @classmethod
+    def _require_a_blob_protocol(cls, value: str) -> str:
+        # abfs/abfss are ADLS-Gen2 (*.dfs.*) endpoints served by the datalake SDK,
+        # not BlobServiceClient; reject rather than silently mis-talk the Blob API.
+        if value in AZURE_REJECTED_PROTOCOLS:
+            raise ValueError(f"connection-protocol {value} (ADLS-Gen2) is not supported")
+        # Anything outside the integrator's documented set would fall through to
+        # the plaintext branch of the account URL and fail obscurely at request
+        # time; refuse it here, at the relation boundary, instead.
+        if value not in AZURE_HTTPS_PROTOCOLS | AZURE_HTTP_PROTOCOLS:
+            raise ValueError(f"connection-protocol {value} is not an Azure Blob protocol")
+        return value
+
+
 # Every backend's validated credentials envelope. A backend widens this union,
 # and the layers above (ClusterState, BackupManager, build_backend) follow
 # without a signature change of their own.
-BackupCredentials = S3Parameters
+BackupCredentials = S3Parameters | AzureStorageParameters
 
 
 class PeerAppModel(PeerModel):
@@ -141,6 +224,7 @@ class PeerAppModel(PeerModel):
     client_user_epoch: float = Field(default=0)
     ldap_user_epoch: float | int = Field(default=0)
     s3_credentials: ExtraSecretStr = Field(default=None)
+    azure_credentials: ExtraSecretStr = Field(default=None)
     restore_id: str = Field(default="")
     restore_token: str = Field(default="")
     restore_instruction: str = Field(default="")
@@ -377,6 +461,21 @@ class ValkeyCluster(RelationState):
             return None
         try:
             return S3Parameters.model_validate_json(self.model.s3_credentials)
+        except ValidationError:
+            return None
+
+    @property
+    def azure_credentials(self) -> "AzureStorageParameters | None":
+        """Return the parsed Azure Blob connection payload, or None if not set.
+
+        Mirrors ``s3_credentials``: the leader writes a JSON-serialised
+        ``AzureStorageParameters``, and a parse failure here is defensive
+        (the payload was validated before writing) and also reads as unset.
+        """
+        if not self.model or not self.model.azure_credentials:
+            return None
+        try:
+            return AzureStorageParameters.model_validate_json(self.model.azure_credentials)
         except ValidationError:
             return None
 

--- a/src/events/backup.py
+++ b/src/events/backup.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import ops
 from object_storage import (
+    AzureStorageRequirer,
     S3Requirer,
     StorageConnectionInfoChangedEvent,
     StorageConnectionInfoGoneEvent,
@@ -26,8 +27,9 @@ from common.exceptions import (
     ValkeyRestoreError,
     ValkeyWorkloadCommandError,
 )
-from core.models import BackupCredentials, S3Parameters
+from core.models import AzureStorageParameters, BackupCredentials, S3Parameters
 from literals import (
+    AZURE_RELATION_NAME,
     BACKUP_CREDENTIAL_FIELDS,
     PEER_RELATION,
     RESTORE_LOAD_TIMEOUT_S,
@@ -70,9 +72,22 @@ class BackupEvents(ops.Object):
         self.framework.observe(
             self.s3_requirer.on.storage_connection_info_gone, self._on_s3_credentials_gone
         )
+        self.azure_requirer = AzureStorageRequirer(self.charm, AZURE_RELATION_NAME)
+        self.framework.observe(
+            self.azure_requirer.on.storage_connection_info_changed,
+            self._on_azure_credentials_changed,
+        )
+        self.framework.observe(
+            self.azure_requirer.on.storage_connection_info_gone,
+            self._on_azure_credentials_gone,
+        )
         # Every backend's changed path, keyed by its relation: used to re-drive the
-        # others when one integrator goes away and un-blocks them.
-        self._credentials_changed_handlers = {S3_RELATION_NAME: self._on_s3_credentials_changed}
+        # others when one integrator goes away and un-blocks them. Keys must cover
+        # BACKUP_CREDENTIAL_FIELDS or a registered backend never converges.
+        self._credentials_changed_handlers = {
+            S3_RELATION_NAME: self._on_s3_credentials_changed,
+            AZURE_RELATION_NAME: self._on_azure_credentials_changed,
+        }
         # Recover credentials when leadership moves; each handler early-returns if
         # its requirer has no info, so firing them all on leader-elected is safe.
         for handler in self._credentials_changed_handlers.values():
@@ -204,6 +219,32 @@ class BackupEvents(ops.Object):
             self.charm.state.cluster.update({"s3_credentials": ""})
 
         self._reconcile_other_backends(event, exclude=S3_RELATION_NAME)
+
+    def _on_azure_credentials_changed(
+        self,
+        event: StorageConnectionInfoChangedEvent
+        | StorageConnectionInfoGoneEvent
+        | ops.LeaderElectedEvent,
+    ) -> None:
+        """Handle initial and updated Azure Storage integrator credentials."""
+        if not (az_info := self.azure_requirer.get_storage_connection_info()):
+            return
+        logger.info("Azure credentials changed; refreshing backup configuration")
+        self._store_credentials(dict(az_info), AzureStorageParameters, "azure_credentials", event)
+
+    def _on_azure_credentials_gone(self, event: StorageConnectionInfoGoneEvent) -> None:
+        """Handle removal of the Azure Storage credentials relation."""
+        if self._backup_or_restore_in_progress():
+            logger.warning("Backup or restore in progress; deferring credentials_gone")
+            event.defer()
+            return
+
+        # The endpoint CA is an S3-only concept (azure_storage carries no CA
+        # field), so there is nothing on disk to remove here.
+        if self.charm.unit.is_leader():
+            self.charm.state.cluster.update({"azure_credentials": ""})
+
+        self._reconcile_other_backends(event, exclude=AZURE_RELATION_NAME)
 
     def _on_create_backup_action(self, event: ops.ActionEvent) -> None:
         """Run a streaming RDB backup of this unit's Valkey instance to object storage."""

--- a/src/literals.py
+++ b/src/literals.py
@@ -36,7 +36,21 @@ LDAP_CA_CERT_RELATION = "ldap-ca-cert"
 LDAP_RELATION = "ldap"
 EXTERNAL_CLIENTS_RELATION = "valkey-client"
 S3_RELATION_NAME = "s3-credentials"
-BACKUP_CREDENTIAL_FIELDS: dict[str, str] = {S3_RELATION_NAME: "s3_credentials"}
+AZURE_RELATION_NAME = "azure-credentials"
+# azure-storage-integrator connection-protocol values that designate an https/http
+# Blob endpoint. abfs/abfss designate ADLS-Gen2 (*.dfs.*), served by the datalake
+# SDK rather than the Blob SDK, so they are rejected up front.
+AZURE_HTTPS_PROTOCOLS = frozenset({"https", "wasbs"})
+AZURE_HTTP_PROTOCOLS = frozenset({"http", "wasb"})
+AZURE_REJECTED_PROTOCOLS = frozenset({"abfs", "abfss"})
+# Every backup backend: its integrator relation -> the app databag field its
+# validated credentials envelope is stored under. Relation discovery, the
+# mutual-exclusion check, credential selection and the action guards all read
+# this, so a new backend is one entry here plus its model, backend and wiring.
+BACKUP_CREDENTIAL_FIELDS: dict[str, str] = {
+    S3_RELATION_NAME: "s3_credentials",
+    AZURE_RELATION_NAME: "azure_credentials",
+}
 BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 BACKUP_CA_FILENAME = "s3_ca_chain.pem"
 PRE_RESTORE_SUFFIX = ".pre-restore"

--- a/tests/integration/backup/conftest.py
+++ b/tests/integration/backup/conftest.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Fixtures for S3 backup integration tests, backed by MicroCeph.
+"""Fixtures for object-storage backup tests: S3 (MicroCeph) and Azure (Azurite).
 
 MicroCeph's RGW is fronted with a self-signed TLS certificate generated here,
 so the suite exercises the charm's full S3-over-TLS path (CA-chain
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import boto3
 import pytest
+from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob import BlobServiceClient
 from botocore.config import Config
 
 RGW_SSL_PORT = 445
@@ -155,3 +157,169 @@ def s3_bucket(microceph):
     bucket.create()
     bucket.wait_until_exists()
     return bucket
+
+
+# ── Azurite (Azure Blob emulator) ─────────────────────────────────────────────
+# Unlike MicroCeph (a snap, installed above), Azurite ships only as an OCI image,
+# so it needs a container runtime. Two are tried in order -- a host `docker`
+# daemon (what the CI runners have) and microk8s behind a NodePort (what a local
+# k8s dev box has) -- and the suite skips when neither is available.
+AZURITE_PORT = 10000
+AZURITE_NODE_PORT = 30000
+AZURITE_CONTAINER = "valkey-azurite"
+AZURITE_NAMESPACE = "valkey-azurite"
+_AZURITE_IMAGE = "mcr.microsoft.com/azure-storage/azurite:latest"
+# Azurite's well-known development account name + key. Published in Microsoft's
+# emulator docs and hardcoded in Azurite itself -- public test material, not a
+# secret, and it only ever authenticates against the local emulator.
+_AZURITE_ACCOUNT = "devstoreaccount1"
+_AZURITE_KEY = (
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+)
+
+_AZURITE_MANIFEST = f"""
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {AZURITE_NAMESPACE}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: azurite
+  namespace: {AZURITE_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{app: azurite}}
+  template:
+    metadata:
+      labels: {{app: azurite}}
+    spec:
+      containers:
+        - name: azurite
+          image: {_AZURITE_IMAGE}
+          args: ["azurite-blob", "--blobHost", "0.0.0.0", "--blobPort", "{AZURITE_PORT}"]
+          ports:
+            - containerPort: {AZURITE_PORT}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: azurite
+  namespace: {AZURITE_NAMESPACE}
+spec:
+  type: NodePort
+  selector: {{app: azurite}}
+  ports:
+    - port: {AZURITE_PORT}
+      targetPort: {AZURITE_PORT}
+      nodePort: {AZURITE_NODE_PORT}
+"""
+
+
+def _wait_for_port(host: str, port: int, timeout: int = 60) -> bool:
+    for _ in range(timeout):
+        if _port_open(host, port):
+            return True
+        time.sleep(1)
+    return False
+
+
+def _start_azurite_docker() -> None:
+    """Run Azurite's blob endpoint on a host docker daemon; idempotent.
+
+    Reuses a live container, restarts a stopped one, creates it otherwise.
+    """
+    try:
+        running = _run("docker", "inspect", "-f", "{{.State.Running}}", AZURITE_CONTAINER)
+    except subprocess.CalledProcessError:
+        _run(
+            "docker", "run", "-d", "--name", AZURITE_CONTAINER,
+            "-p", f"{AZURITE_PORT}:{AZURITE_PORT}",
+            _AZURITE_IMAGE,
+            "azurite-blob", "--blobHost", "0.0.0.0",
+        )  # fmt: skip
+    else:
+        # A container left stopped by an earlier run never opens the port.
+        if running != "true":
+            _run("docker", "start", AZURITE_CONTAINER)
+
+
+def _start_azurite_microk8s() -> None:
+    """Run Azurite as a microk8s Deployment behind a NodePort; idempotent.
+
+    The manifest goes in on stdin rather than as a path: microk8s is a strict
+    snap with a private /tmp, so it cannot read a file the test process wrote
+    to a temp directory.
+    """
+    _run("microk8s", "kubectl", "apply", "-f", "-", input=_AZURITE_MANIFEST)
+    _run(
+        "microk8s", "kubectl", "-n", AZURITE_NAMESPACE,
+        "rollout", "status", "deploy/azurite", "--timeout=180s",
+    )  # fmt: skip
+
+
+def _ensure_azurite(host_ip: str) -> int:
+    """Start Azurite on whichever runtime is available; return its host port.
+
+    Returns 0 when no runtime could serve it, which the fixture turns into a skip.
+    """
+    for start, port in (
+        (_start_azurite_docker, AZURITE_PORT),
+        (_start_azurite_microk8s, AZURITE_NODE_PORT),
+    ):
+        try:
+            start()
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            continue  # runtime missing or refused; try the next one
+        if _wait_for_port(host_ip, port):
+            return port
+    return 0
+
+
+@pytest.fixture(scope="module")
+def azurite() -> dict:
+    """Start Azurite and return the azure_storage envelope pointing at it.
+
+    Reachable from charm units at the host's routable IP -- never loopback,
+    which from a unit resolves to the unit itself (same rationale as the
+    MicroCeph fixture). `endpoint` embeds the dev account in the path and
+    `connection-protocol` is plain `http`, which azure-storage-integrator
+    accepts for Blob REST access, so it talks to the emulator, not real Azure.
+    """
+    host_ip = _host_ip()
+    if not (port := _ensure_azurite(host_ip)):
+        pytest.skip("Azurite needs a host docker daemon or a running microk8s")
+
+    return {
+        "container": f"valkey-backup-{secrets.token_hex(4)}",
+        "storage-account": _AZURITE_ACCOUNT,
+        "secret-key": _AZURITE_KEY,
+        "connection-protocol": "http",
+        "endpoint": f"http://{host_ip}:{port}/{_AZURITE_ACCOUNT}",
+        "path": "valkey",
+    }
+
+
+@pytest.fixture(scope="module")
+def azure_container(azurite: dict):
+    """Return an Azure ContainerClient for the test container, creating it eagerly.
+
+    Mirrors `s3_bucket`, and built exactly the way the charm's AzureBackend builds
+    its client (account_url = endpoint, account named explicitly), so the test
+    inspects the very store the charm writes to.
+    """
+    service = BlobServiceClient(
+        account_url=azurite["endpoint"],
+        credential={
+            "account_name": azurite["storage-account"],
+            "account_key": azurite["secret-key"],
+        },
+    )
+    container = service.get_container_client(azurite["container"])
+    try:
+        container.create_container()
+    except ResourceExistsError:
+        pass  # re-run against an already-created container
+    return container

--- a/tests/integration/backup/helpers.py
+++ b/tests/integration/backup/helpers.py
@@ -2,7 +2,7 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Shared helpers for the S3 backup/restore integration tests."""
+"""Shared helpers for the object-storage backup/restore integration tests."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ from tests.integration.helpers import APP_NAME, IMAGE_RESOURCE, are_apps_active_
 
 S3_INTEGRATOR_APP = "s3-integrator"
 S3_CREDS_SECRET = "s3-creds"
+AZURE_INTEGRATOR_APP = "azure-storage-integrator"
+AZURE_CREDS_SECRET = "azure-creds"
 BACKUP_ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
 
 
@@ -99,6 +101,91 @@ def deploy_and_relate_s3(
     juju.wait(
         lambda status: are_apps_active_and_agents_idle(
             status, APP_NAME, S3_INTEGRATOR_APP, idle_period=30
+        ),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+
+
+def deploy_and_relate_azure(
+    juju: jubilant.Juju,
+    charm: str,
+    substrate: Substrate,
+    azurite: dict,
+    num_units: int = 3,
+) -> None:
+    """Deploy the local valkey charm + azure-storage-integrator, wire creds, and relate them.
+
+    Mirrors ``deploy_and_relate_s3``: idempotent, each step skipped when already
+    done, so it is safe to call at the top of every test and again after a
+    redeploy. The integrator setup is guarded on the integrator app's presence,
+    and the valkey app is (re)deployed and (re)related on its own.
+
+    The `azurite` fixture mints a fresh container name per run, so a model left
+    over from an earlier run keeps the *old* container in the integrator's config
+    (`juju remove-application azure-storage-integrator` + `juju remove-secret
+    azure-creds` between runs, or backups land where the test does not look).
+    """
+    status = juju.status()
+
+    if AZURE_INTEGRATOR_APP not in status.apps:
+        juju.deploy(AZURE_INTEGRATOR_APP, channel="1/edge")
+        # azure-storage-integrator takes the account key as a Juju secret (content
+        # key `secret-key`): create + grant it, then point `credentials` at its URI.
+        # The rest is plain config -- for Azurite, `connection-protocol=http` plus an
+        # explicit `endpoint` keeps the integrator on the emulator, not real Azure.
+        creds = juju.add_secret(
+            name=AZURE_CREDS_SECRET,
+            content={"secret-key": azurite["secret-key"]},
+        )
+        juju.grant_secret(identifier=creds, app=AZURE_INTEGRATOR_APP)
+        juju.config(
+            AZURE_INTEGRATOR_APP,
+            {
+                "credentials": creds,
+                "container": azurite["container"],
+                "storage-account": azurite["storage-account"],
+                "connection-protocol": azurite["connection-protocol"],
+                "endpoint": azurite["endpoint"],
+                # Required by the charm even though the integrator defaults it to
+                # "": an empty prefix would let list-backups enumerate the whole
+                # container.
+                "path": azurite["path"],
+            },
+        )
+
+    # Always deploy the local charm under test -- never a Charmhub revision.
+    if APP_NAME not in status.apps:
+        juju.deploy(
+            charm,
+            resources=IMAGE_RESOURCE if substrate == Substrate.K8S else None,
+            num_units=num_units,
+            trust=True,
+        )
+
+    # Require agents idle as well as workloads active: after `integrate` the
+    # workloads stay active while the leader's relation hooks (ensure_container +
+    # credential storage) are still running, so a workload-only wait can return
+    # before Azure is actually wired up.
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(
+            status, APP_NAME, AZURE_INTEGRATOR_APP, idle_period=30
+        ),
+        timeout=1000,
+        delay=5,
+        successes=3,
+    )
+
+    # Integrate only when the relation does not yet exist (a redeploy drops it).
+    try:
+        juju.integrate(APP_NAME, AZURE_INTEGRATOR_APP)
+    except jubilant.CLIError as exc:
+        if "already exists" not in str(exc).lower():
+            raise
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(
+            status, APP_NAME, AZURE_INTEGRATOR_APP, idle_period=30
         ),
         timeout=1000,
         delay=5,

--- a/tests/integration/backup/test_azure_backup.py
+++ b/tests/integration/backup/test_azure_backup.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""End-to-end Azure Blob backup/restore integration test against Azurite.
+
+Mirrors ``test_s3_backup.py`` (any-unit backup, list ordering, object presence,
+RDB magic) against azure-storage-integrator + the Azurite emulator, and adds a
+restore smoke on the leader (the ``restore`` action is leader-only).
+
+Needs a bootstrapped Juju controller, a built charm, and a host docker daemon
+for Azurite -- the suite skips when docker is unavailable:
+
+    tox run -e integration -- tests/integration/backup/test_azure_backup.py --substrate k8s
+"""
+
+from __future__ import annotations
+
+import time
+
+import jubilant
+
+from literals import Substrate
+from tests.integration.backup.helpers import BACKUP_ID_RE, deploy_and_relate_azure
+from tests.integration.helpers import APP_NAME, are_apps_active_and_agents_idle
+
+
+def test_backup_list_and_restore(
+    charm: str,
+    juju: jubilant.Juju,
+    substrate: Substrate,
+    azurite: dict,
+    azure_container,
+) -> None:
+    deploy_and_relate_azure(juju, charm, substrate, azurite)
+
+    # Three distinct units exercise the any-unit backup guarantee.
+    units = list(juju.status().get_units(APP_NAME))
+    assert len(units) >= 3, units
+
+    # Backup from the first unit.
+    task0 = juju.run(units[0], "create-backup")
+    assert task0.success, task0.stderr
+    backup_id_0 = task0.results["backup-id"]
+    assert BACKUP_ID_RE.match(backup_id_0), backup_id_0
+
+    # Backup from a second unit (distinct id, exercises any-unit guarantee).
+    time.sleep(2)
+    task1 = juju.run(units[1], "create-backup")
+    assert task1.success, task1.stderr
+    backup_id_1 = task1.results["backup-id"]
+    assert backup_id_1 != backup_id_0
+
+    # List from a third unit. Newest first.
+    listing = juju.run(units[2], "list-backups")
+    assert listing.success
+    table = listing.results["backups"]
+    assert backup_id_0 in table
+    assert backup_id_1 in table
+    assert table.index(backup_id_1) < table.index(backup_id_0)
+
+    # Verify the blobs exist under the configured path prefix.
+    names = [b.name for b in azure_container.list_blobs(name_starts_with=azurite["path"])]
+    assert any(backup_id_0 in n for n in names), names
+    assert any(backup_id_1 in n for n in names), names
+
+    # Validate RDB magic bytes for the first object.
+    name = next(n for n in names if backup_id_0 in n)
+    head = azure_container.download_blob(name, offset=0, length=9).readall()
+    assert head.startswith(b"REDIS") or head.startswith(b"VALKEY"), head
+
+    # Restore smoke: the restore action is leader-only. Initiating it must succeed
+    # and the cluster must converge back to active/idle.
+    restore = juju.run(f"{APP_NAME}/leader", "restore", {"backup-id": backup_id_0})
+    assert restore.success, restore.stderr
+    assert "restore" in restore.results, f"Unexpected action results: {restore.results}"
+    juju.wait(
+        lambda status: are_apps_active_and_agents_idle(status, APP_NAME, idle_period=30),
+        timeout=1200,
+        delay=5,
+        successes=3,
+    )

--- a/tests/spread/k8s/test_azure_backup.py/task.yaml
+++ b/tests/spread/k8s/test_azure_backup.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_azure_backup.py
+environment:
+  TEST_MODULE: test_azure_backup.py
+execute: |
+  tox run -e integration -- "tests/integration/backup/$TEST_MODULE" --substrate k8s --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/spread/vm/test_azure_backup.py/task.yaml
+++ b/tests/spread/vm/test_azure_backup.py/task.yaml
@@ -1,0 +1,7 @@
+summary: test_azure_backup.py
+environment:
+  TEST_MODULE: test_azure_backup.py
+execute: |
+  tox run -e integration -- "tests/integration/backup/$TEST_MODULE" --substrate vm --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -151,45 +151,37 @@ def test_active_backup_credentials_follows_the_relation(cloud_spec, mocker):
 def test_backup_credential_registry_maps_relations_to_databag_fields():
     """Adding a backend is one registry entry: its relation and where creds land."""
     from src.core.models import PeerAppModel
-    from src.literals import BACKUP_CREDENTIAL_FIELDS, S3_RELATION_NAME
+    from src.literals import AZURE_RELATION_NAME, BACKUP_CREDENTIAL_FIELDS, S3_RELATION_NAME
 
     assert BACKUP_CREDENTIAL_FIELDS[S3_RELATION_NAME] == "s3_credentials"
+    assert BACKUP_CREDENTIAL_FIELDS[AZURE_RELATION_NAME] == "azure_credentials"
     # Every registered field must exist on the app databag model, or the leader
     # would silently write credentials nothing reads back.
     for field in BACKUP_CREDENTIAL_FIELDS.values():
         assert field in PeerAppModel.model_fields
 
 
-def test_backup_relations_and_conflict_follow_the_registry(cloud_spec, mocker):
+def test_backup_relations_and_conflict_follow_the_registry(cloud_spec):
     """Relation discovery and the conflict check are driven by the registry alone.
 
-    Exercised with a second entry patched in (there is only one backend today),
-    which is what a future backend's entry will look like.
+    Exercised with the two registered backends, so it also pins the mutual
+    exclusion the charm enforces: relate exactly one storage integrator.
     """
     from ops import testing
 
     from src.charm import ValkeyCharm
     from src.literals import (
-        CLIENT_TLS_RELATION_NAME,
+        AZURE_RELATION_NAME,
         PEER_RELATION,
         S3_RELATION_NAME,
         STATUS_PEERS_RELATION,
-    )
-
-    # CLIENT_TLS stands in for a second backup integrator until one exists.
-    mocker.patch.dict(
-        "core.cluster_state.BACKUP_CREDENTIAL_FIELDS",
-        {S3_RELATION_NAME: "s3_credentials", CLIENT_TLS_RELATION_NAME: "s3_credentials"},
-        clear=True,
     )
 
     ctx = testing.Context(ValkeyCharm, app_trusted=True)
     peer = testing.PeerRelation(id=1, endpoint=PEER_RELATION)
     status_peer = testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION)
     s3_rel = testing.Relation(id=3, endpoint=S3_RELATION_NAME, interface="s3")
-    second = testing.Relation(
-        id=4, endpoint=CLIENT_TLS_RELATION_NAME, interface="tls-certificates"
-    )
+    azure_rel = testing.Relation(id=4, endpoint=AZURE_RELATION_NAME, interface="azure_storage")
     common = {
         "model": testing.Model(name="m", type="lxd", cloud_spec=cloud_spec),
         "leader": True,
@@ -201,7 +193,12 @@ def test_backup_relations_and_conflict_follow_the_registry(cloud_spec, mocker):
         assert len(manager.charm.state.backup_relations) == 1
         assert manager.charm.state.backup_backends_conflict is False
 
-    both = testing.State(relations={peer, status_peer, s3_rel, second}, **common)
+    other = testing.State(relations={peer, status_peer, azure_rel}, **common)
+    with ctx(ctx.on.update_status(), other) as manager:
+        assert len(manager.charm.state.backup_relations) == 1
+        assert manager.charm.state.backup_backends_conflict is False
+
+    both = testing.State(relations={peer, status_peer, s3_rel, azure_rel}, **common)
     with ctx(ctx.on.update_status(), both) as manager:
         assert len(manager.charm.state.backup_relations) == 2
         assert manager.charm.state.backup_backends_conflict is True
@@ -1259,6 +1256,10 @@ def test_create_backup_kills_producer_on_upload_failure(mocker):
     # The lock is still released on the way out.
     assert state.unit_server.update.call_args_list[-1].args[0] == {"backup_id": ""}
 
+
+# ── Azure Blob backend ──────────────────────────────────────────────────
+
+
 def test_metadata_declares_azure_relation():
     """The Azure integrator relation is declared and mutually exclusive-friendly."""
     import pathlib
@@ -1270,3 +1271,161 @@ def test_metadata_declares_azure_relation():
     assert az["interface"] == "azure_storage"
     assert az["limit"] == 1
     assert az["optional"] is True
+
+
+def test_azure_parameters_valid_and_normalised():
+    """Trims whitespace, strips the separators that would corrupt blob keys."""
+    from src.core.models import AzureStorageParameters
+
+    p = AzureStorageParameters.model_validate(
+        {
+            "container": " c ",
+            "storage-account": "acct",
+            "secret-key": " KEY ",
+            "connection-protocol": "https",
+            "endpoint": "https://acct.blob.core.windows.net/",
+            "path": "/valkey/",
+        }
+    )
+    assert p.container == "c"
+    assert p.storage_account == "acct"
+    assert p.secret_key == "KEY"
+    assert p.path == "valkey"
+    assert p.endpoint == "https://acct.blob.core.windows.net"
+    assert p.resource_group is None
+
+
+def test_azure_parameters_lowercases_the_connection_protocol():
+    """The protocol is matched against the scheme sets, which are lowercase.
+
+    An integrator sending "HTTPS" must not fall through to the http branch of
+    the account URL.
+    """
+    from src.core.models import AzureStorageParameters
+
+    p = AzureStorageParameters.model_validate(
+        {
+            "container": "c",
+            "storage-account": "a",
+            "secret-key": "k",
+            "connection-protocol": "HTTPS",
+            "path": "valkey",
+        }
+    )
+    assert p.connection_protocol == "https"
+
+
+def test_azure_parameters_rejects_empty_required():
+    """An empty path would make list_backups enumerate the whole container."""
+    import pytest
+    from pydantic import ValidationError
+
+    from src.core.models import AzureStorageParameters
+
+    base = {
+        "container": "c",
+        "storage-account": "a",
+        "secret-key": "k",
+        "connection-protocol": "https",
+        "path": "valkey",
+    }
+    for field in ("container", "storage-account", "secret-key", "connection-protocol", "path"):
+        with pytest.raises(ValidationError):
+            AzureStorageParameters.model_validate({**base, field: ""})
+
+
+def test_azure_parameters_rejects_adls_protocols():
+    """abfs/abfss are ADLS-Gen2, served by the datalake SDK -- not BlobServiceClient."""
+    import pytest
+    from pydantic import ValidationError
+
+    from src.core.models import AzureStorageParameters
+
+    for proto in ("abfs", "abfss", "ABFSS"):
+        with pytest.raises(ValidationError):
+            AzureStorageParameters.model_validate(
+                {
+                    "container": "c",
+                    "storage-account": "a",
+                    "secret-key": "k",
+                    "connection-protocol": proto,
+                    "path": "valkey",
+                }
+            )
+
+
+def test_peer_app_model_has_azure_credentials_field():
+    from src.core.models import PeerAppModel
+
+    fields = PeerAppModel.model_fields
+    assert "azure_credentials" in fields
+    assert fields["azure_credentials"].default is None
+
+
+def test_cluster_azure_credentials_parses_envelope_and_defaults_none(mocker):
+    """The stored envelope parses back to AzureStorageParameters; unset reads as None."""
+    from src.core.models import AzureStorageParameters, ValkeyCluster
+
+    cluster = ValkeyCluster.__new__(ValkeyCluster)
+    cluster.model = mocker.MagicMock()
+
+    params = AzureStorageParameters.model_validate(
+        {
+            "container": "c",
+            "storage-account": "a",
+            "secret-key": "k",
+            "connection-protocol": "https",
+            "path": "valkey",
+        }
+    )
+    cluster.model.azure_credentials = params.model_dump_json(by_alias=True)
+    got = cluster.azure_credentials
+    assert isinstance(got, AzureStorageParameters)
+    assert got.container == "c"
+    assert got.secret_key == "k"
+
+    cluster.model.azure_credentials = None
+    assert cluster.azure_credentials is None
+
+    cluster.model = None
+    assert cluster.azure_credentials is None
+
+
+def test_azure_parameters_rejects_an_unknown_connection_protocol():
+    """Only the six documented integrator values are accepted.
+
+    Anything else would fall through to the plaintext branch of the account URL
+    and fail obscurely at request time instead of at the relation boundary.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from src.core.models import AzureStorageParameters
+
+    with pytest.raises(ValidationError):
+        AzureStorageParameters.model_validate(
+            {
+                "container": "c",
+                "storage-account": "a",
+                "secret-key": "k",
+                "connection-protocol": "ftp",
+                "path": "valkey",
+            }
+        )
+
+
+def test_azure_parameters_accepts_every_blob_connection_protocol():
+    from src.core.models import AzureStorageParameters
+    from src.literals import AZURE_HTTP_PROTOCOLS, AZURE_HTTPS_PROTOCOLS
+
+    for proto in AZURE_HTTPS_PROTOCOLS | AZURE_HTTP_PROTOCOLS:
+        params = AzureStorageParameters.model_validate(
+            {
+                "container": "c",
+                "storage-account": "a",
+                "secret-key": "k",
+                "connection-protocol": proto,
+                "path": "valkey",
+            }
+        )
+        assert params.connection_protocol == proto

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1258,3 +1258,15 @@ def test_create_backup_kills_producer_on_upload_failure(mocker):
     backend.delete.assert_not_called()
     # The lock is still released on the way out.
     assert state.unit_server.update.call_args_list[-1].args[0] == {"backup_id": ""}
+
+def test_metadata_declares_azure_relation():
+    """The Azure integrator relation is declared and mutually exclusive-friendly."""
+    import pathlib
+
+    import yaml
+
+    meta = yaml.safe_load(pathlib.Path("metadata.yaml").read_text())
+    az = meta["requires"]["azure-credentials"]
+    assert az["interface"] == "azure_storage"
+    assert az["limit"] == 1
+    assert az["optional"] is True

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1391,6 +1391,190 @@ def test_cluster_azure_credentials_parses_envelope_and_defaults_none(mocker):
     assert cluster.azure_credentials is None
 
 
+def test_credentials_changed_handlers_cover_every_registered_backend(mocker, cloud_spec):
+    """Every registry entry has a changed handler, or its integrator is inert.
+
+    ``_reconcile_other_backends`` and the leader_elected recovery observers are
+    both generated from this table, so a missing entry silently loses a backend.
+    """
+    from ops import testing
+
+    from src.charm import ValkeyCharm
+    from src.literals import BACKUP_CREDENTIAL_FIELDS, PEER_RELATION, STATUS_PEERS_RELATION
+
+    ctx = testing.Context(ValkeyCharm, app_trusted=True)
+    state_in = testing.State(
+        model=testing.Model(name="m", type="lxd", cloud_spec=cloud_spec),
+        leader=True,
+        relations={
+            testing.PeerRelation(id=1, endpoint=PEER_RELATION),
+            testing.PeerRelation(id=2, endpoint=STATUS_PEERS_RELATION),
+        },
+        containers={testing.Container(name="valkey", can_connect=True)},
+    )
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        handlers = manager.charm.backup_events._credentials_changed_handlers
+    assert set(handlers) == set(BACKUP_CREDENTIAL_FIELDS)
+
+
+def test_on_azure_credentials_changed_leader_writes_databag(mocker):
+    """The Azure handler delegates the leader/conflict/validate/store half."""
+    import json
+
+    from src.events.backup import BackupEvents
+
+    charm = mocker.MagicMock()
+    charm.unit.is_leader.return_value = True
+    charm.state.peer_relation = mocker.MagicMock()
+    charm.state.backup_backends_conflict = False
+    charm.state.is_backup_in_progress_any = False
+    charm.state.cluster.is_restore_in_progress = False
+
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt.azure_requirer = mocker.MagicMock()
+    evt.azure_requirer.get_storage_connection_info.return_value = {
+        "container": " c ",
+        "storage-account": "acct",
+        "secret-key": "SK",
+        "connection-protocol": "https",
+        "path": "/valkey/",
+    }
+
+    evt._on_azure_credentials_changed(mocker.MagicMock())
+
+    charm.backup_manager.ensure_container.assert_called_once()
+    args, _ = charm.state.cluster.update.call_args
+    creds = json.loads(args[0]["azure_credentials"])
+    assert creds["container"] == "c"
+    assert creds["path"] == "valkey"
+    assert creds["storage-account"] == "acct"
+
+
+def test_on_azure_credentials_changed_without_info_is_a_noop(mocker):
+    """Fired on leader_elected with no Azure relation: nothing to store."""
+    from src.events.backup import BackupEvents
+
+    charm = mocker.MagicMock()
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt.azure_requirer = mocker.MagicMock()
+    evt.azure_requirer.get_storage_connection_info.return_value = {}
+
+    evt._on_azure_credentials_changed(mocker.MagicMock())
+
+    charm.state.cluster.update.assert_not_called()
+    charm.backup_manager.ensure_container.assert_not_called()
+
+
+def test_on_azure_credentials_changed_never_touches_the_s3_ca(mocker):
+    """The endpoint CA is an S3-only concept; Azure must not clobber the file."""
+    from src.events.backup import BackupEvents
+
+    charm = mocker.MagicMock()
+    charm.unit.is_leader.return_value = False
+
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt.azure_requirer = mocker.MagicMock()
+    evt.azure_requirer.get_storage_connection_info.return_value = {
+        "container": "c",
+        "storage-account": "acct",
+        "secret-key": "SK",
+        "connection-protocol": "https",
+        "path": "valkey",
+    }
+
+    evt._on_azure_credentials_changed(mocker.MagicMock())
+
+    charm.backup_manager.store_tls_ca_chain.assert_not_called()
+    charm.backup_manager.remove_tls_ca_chain.assert_not_called()
+
+
+def test_on_azure_credentials_gone_defers_during_backup(mocker):
+    from src.events.backup import BackupEvents
+
+    charm = mocker.MagicMock()
+    charm.state.is_backup_in_progress_any = True
+
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    event = mocker.MagicMock()
+
+    evt._on_azure_credentials_gone(event)
+
+    event.defer.assert_called_once()
+    charm.state.cluster.update.assert_not_called()
+
+
+def test_on_azure_credentials_gone_clears_databag_and_converges_s3(mocker):
+    """Removing the Azure integrator clears the conflict, so S3 gets another go."""
+    from src.events.backup import BackupEvents
+    from src.literals import AZURE_RELATION_NAME, S3_RELATION_NAME
+
+    charm = mocker.MagicMock()
+    charm.state.is_backup_in_progress_any = False
+    charm.state.cluster.is_restore_in_progress = False
+    charm.unit.is_leader.return_value = True
+
+    s3_handler = mocker.Mock()
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt._credentials_changed_handlers = {
+        S3_RELATION_NAME: s3_handler,
+        AZURE_RELATION_NAME: mocker.Mock(),
+    }
+
+    evt._on_azure_credentials_gone(mocker.MagicMock())
+
+    charm.state.cluster.update.assert_called_once_with({"azure_credentials": ""})
+    # Azure carries no charm-local CA, so nothing on disk is touched.
+    charm.backup_manager.remove_tls_ca_chain.assert_not_called()
+    s3_handler.assert_called_once()
+    evt._credentials_changed_handlers[AZURE_RELATION_NAME].assert_not_called()
+
+
+def test_on_azure_credentials_gone_non_leader_does_not_clear_databag(mocker):
+    from src.events.backup import BackupEvents
+
+    charm = mocker.MagicMock()
+    charm.state.is_backup_in_progress_any = False
+    charm.state.cluster.is_restore_in_progress = False
+    charm.unit.is_leader.return_value = False
+
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt._credentials_changed_handlers = {}
+
+    evt._on_azure_credentials_gone(mocker.MagicMock())
+
+    charm.state.cluster.update.assert_not_called()
+
+
+def test_on_s3_credentials_gone_converges_the_surviving_azure_backend(mocker):
+    """The mirror case: dropping S3 must re-drive the still-related Azure backend."""
+    from src.events.backup import BackupEvents
+    from src.literals import AZURE_RELATION_NAME, S3_RELATION_NAME
+
+    charm = mocker.MagicMock()
+    charm.state.is_backup_in_progress_any = False
+    charm.state.cluster.is_restore_in_progress = False
+    charm.unit.is_leader.return_value = True
+
+    azure_handler = mocker.Mock()
+    evt = BackupEvents.__new__(BackupEvents)
+    evt.charm = charm
+    evt._credentials_changed_handlers = {
+        S3_RELATION_NAME: mocker.Mock(),
+        AZURE_RELATION_NAME: azure_handler,
+    }
+
+    evt._on_s3_credentials_gone(mocker.MagicMock())
+
+    charm.state.cluster.update.assert_called_once_with({"s3_credentials": ""})
+    azure_handler.assert_called_once()
+
+
 def test_azure_parameters_rejects_an_unknown_connection_protocol():
     """Only the six documented integrator values are accepted.
 

--- a/tests/unit/test_storage_backend.py
+++ b/tests/unit/test_storage_backend.py
@@ -294,3 +294,329 @@ def test_build_backend_rejects_unknown_credentials(mocker):
 
     with pytest.raises(StorageBackendError):
         build_backend(object(), mocker.MagicMock())  # pyright: ignore[reportArgumentType]
+
+
+# ── Azure Blob backend ──────────────────────────────────────────────────
+
+
+def _az_params(**overrides):
+    """Build a valid AzureStorageParameters, overriding individual fields by name.
+
+    Flat import, for the same reason as `_s3_params`: `build_backend` dispatches
+    on isinstance, and the `src.`-prefixed copy is a different class object.
+    """
+    from core.models import AzureStorageParameters
+
+    base = {
+        "container": "c",
+        "storage-account": "acct",
+        "secret-key": "SK",
+        "connection-protocol": "https",
+        "path": "valkey",
+    }
+    base.update(overrides)
+    return AzureStorageParameters.model_validate(base)
+
+
+def _az_backend(mocker, **overrides):
+    """Build an AzureBackend with its ContainerClient faked; return (backend, container)."""
+    from src.common.storage_backend import AzureBackend
+
+    container = mocker.MagicMock()
+    mocker.patch.object(AzureBackend, "_container", return_value=container)
+    return AzureBackend(_az_params(**overrides)), container
+
+
+def _http_error(code, message="boom"):
+    """Build an azure-storage failure carrying a structured code, as the SDK raises it.
+
+    ``process_storage_error`` attaches ``error_code`` as a ``StorageErrorCode``
+    -- a (str, Enum) member -- which is what the backend has to translate.
+    """
+    from azure.core.exceptions import HttpResponseError
+
+    exc = HttpResponseError(message=message)
+    exc.error_code = code
+    return exc
+
+
+# ── client construction ─────────────────────────────────────────────────
+
+
+def test_azurebackend_account_url_defaults_to_the_blob_host(mocker):
+    backend, _ = _az_backend(mocker)
+    assert backend._account_url() == "https://acct.blob.core.windows.net"
+
+
+def test_azurebackend_account_url_follows_the_connection_protocol(mocker):
+    """wasb/http are plaintext Blob; wasbs/https are TLS."""
+    for proto, scheme in (
+        ("https", "https"),
+        ("wasbs", "https"),
+        ("http", "http"),
+        ("wasb", "http"),
+    ):
+        backend, _ = _az_backend(mocker, **{"connection-protocol": proto})
+        assert backend._account_url() == f"{scheme}://acct.blob.core.windows.net"
+
+
+def test_azurebackend_account_url_honours_an_explicit_endpoint(mocker):
+    """An emulator or private endpoint replaces the derived account URL wholesale."""
+    backend, _ = _az_backend(mocker, endpoint="http://10.0.0.5:10000/devstoreaccount1")
+    assert backend._account_url() == "http://10.0.0.5:10000/devstoreaccount1"
+
+
+def test_azurebackend_service_client_names_the_account_explicitly(mocker):
+    """The account name is passed, not left to the SDK to infer from the URL.
+
+    A bare string credential makes azure-storage derive the account from the
+    host's first label, which raises "Unable to determine account name for
+    shared key credential" for any endpoint whose host is not
+    ``<account>.blob.*`` -- an emulator or a custom domain, where the account
+    sits in the URL path instead.
+    """
+    from src.common import storage_backend
+
+    service_cls = mocker.patch.object(storage_backend, "BlobServiceClient")
+    from src.common.storage_backend import AzureBackend
+
+    AzureBackend(_az_params())._service()
+
+    _, kwargs = service_cls.call_args
+    assert kwargs["account_url"] == "https://acct.blob.core.windows.net"
+    assert kwargs["credential"] == {"account_name": "acct", "account_key": "SK"}
+
+
+def test_azurebackend_service_client_works_for_a_path_style_endpoint(mocker):
+    """The emulator case: host is an IP, the account is the first path segment."""
+    from src.common import storage_backend
+
+    service_cls = mocker.patch.object(storage_backend, "BlobServiceClient")
+    from src.common.storage_backend import AzureBackend
+
+    AzureBackend(
+        _az_params(
+            endpoint="http://10.0.0.5:10000/devstoreaccount1",
+            **{"storage-account": "devstoreaccount1", "connection-protocol": "http"},
+        )
+    )._service()
+
+    _, kwargs = service_cls.call_args
+    assert kwargs["account_url"] == "http://10.0.0.5:10000/devstoreaccount1"
+    assert kwargs["credential"]["account_name"] == "devstoreaccount1"
+
+
+def test_azurebackend_location_names_the_destination_without_credentials(mocker):
+    """The audit trail gets host/container/prefix -- never a SAS token or userinfo."""
+    backend, _ = _az_backend(
+        mocker, endpoint="https://acct.blob.core.windows.net:8443/?sig=SECRETTOKEN"
+    )
+    assert backend.location == "azure://acct.blob.core.windows.net:8443/c/valkey"
+    assert "SECRETTOKEN" not in backend.location
+
+    plain, _ = _az_backend(mocker)
+    assert plain.location == "azure://acct.blob.core.windows.net/c/valkey"
+
+
+# ── container lifecycle ─────────────────────────────────────────────────
+
+
+def test_azurebackend_ensure_container_creates_it(mocker):
+    backend, container = _az_backend(mocker)
+
+    backend.ensure_container()
+
+    container.create_container.assert_called_once_with()
+
+
+def test_azurebackend_ensure_container_tolerates_an_existing_container(mocker):
+    from azure.core.exceptions import ResourceExistsError
+
+    backend, container = _az_backend(mocker)
+    container.create_container.side_effect = ResourceExistsError("exists")
+
+    backend.ensure_container()  # must not raise
+
+
+def test_azurebackend_ensure_container_wraps_other_http_errors(mocker):
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.create_container.side_effect = _http_error("AuthenticationFailed")
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.ensure_container()
+    assert excinfo.value.safe_code == "AuthenticationFailed"
+
+
+def test_azurebackend_safe_code_is_the_wire_code_not_the_enum_repr(mocker):
+    """azure-storage sets error_code to a StorageErrorCode member.
+
+    Its str() renders "StorageErrorCode.AUTHENTICATION_FAILED"; the action result
+    must carry the wire code the provider returned, matching the S3 side.
+    """
+    from azure.storage.blob import StorageErrorCode
+
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.create_container.side_effect = _http_error(StorageErrorCode.AUTHENTICATION_FAILED)
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.ensure_container()
+    assert excinfo.value.safe_code == "AuthenticationFailed"
+
+
+def test_azurebackend_safe_code_empty_when_the_sdk_attached_none(mocker):
+    """A transport-level failure carries no provider code; the action falls back."""
+    from azure.core.exceptions import HttpResponseError
+
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.create_container.side_effect = HttpResponseError(message="connection reset")
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.ensure_container()
+    assert excinfo.value.safe_code == ""
+
+
+# ── list ────────────────────────────────────────────────────────────────
+
+
+def test_azurebackend_list_object_ids_filters_by_prefix_and_strips_it(mocker):
+    backend, container = _az_backend(mocker)
+    container.list_blobs.return_value = [mocker.MagicMock(name=n) for n in ("a", "b")]
+    # MagicMock(name=...) sets the mock's own name, not the attribute; set it explicitly.
+    for blob, name in zip(
+        container.list_blobs.return_value, ("valkey/2026-05-13T10:00:00Z", "valkey/other")
+    ):
+        blob.name = name
+
+    assert backend.list_object_ids() == ["2026-05-13T10:00:00Z", "other"]
+    container.list_blobs.assert_called_once_with(name_starts_with="valkey/")
+
+
+def test_azurebackend_list_object_ids_wraps_http_errors(mocker):
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.list_blobs.side_effect = _http_error("ContainerNotFound")
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.list_object_ids()
+    assert excinfo.value.safe_code == "ContainerNotFound"
+
+
+# ── head / upload / download / delete ───────────────────────────────────
+
+
+def test_azurebackend_head_ranges_over_the_first_bytes_only(mocker):
+    backend, container = _az_backend(mocker)
+    blob = container.get_blob_client.return_value
+    blob.download_blob.return_value.readall.return_value = b"REDIS0011"
+
+    assert backend.head("2026-05-13T10:00:00Z") == b"REDIS0011"
+    container.get_blob_client.assert_called_once_with("valkey/2026-05-13T10:00:00Z")
+    blob.download_blob.assert_called_once_with(offset=0, length=16)
+
+
+def test_azurebackend_head_wraps_http_errors(mocker):
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.get_blob_client.return_value.download_blob.side_effect = _http_error("BlobNotFound")
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.head("2026-05-13T10:00:00Z")
+    assert excinfo.value.safe_code == "BlobNotFound"
+
+
+def test_azurebackend_upload_streams_to_the_backup_id_blob(mocker):
+    """Single-shot, max_concurrency=1: the source is a non-rewindable pipe."""
+    backend, container = _az_backend(mocker)
+    blob = container.get_blob_client.return_value
+    reader = mocker.MagicMock()
+
+    backend.upload("2026-05-13T10:00:00Z", reader)
+
+    container.get_blob_client.assert_called_once_with("valkey/2026-05-13T10:00:00Z")
+    args, kwargs = blob.upload_blob.call_args
+    assert args[0] is reader
+    assert kwargs["blob_type"] == "BlockBlob"
+    assert kwargs["overwrite"] is True
+    assert kwargs["length"] is None
+    assert kwargs["max_concurrency"] == 1
+
+
+def test_azurebackend_upload_wraps_http_errors(mocker):
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.get_blob_client.return_value.upload_blob.side_effect = _http_error(
+        "AccountIsDisabled"
+    )
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.upload("2026-05-13T10:00:00Z", mocker.MagicMock())
+    assert excinfo.value.safe_code == "AccountIsDisabled"
+
+
+def test_azurebackend_download_returns_the_downloader_and_its_length(mocker):
+    """The downloader already knows the blob size, so the restore trail is free."""
+    backend, container = _az_backend(mocker)
+    downloader = container.get_blob_client.return_value.download_blob.return_value
+    downloader.size = 4096
+
+    obj = backend.download("2026-05-13T10:00:00Z")
+
+    assert obj.body is downloader
+    assert obj.size == 4096
+    container.get_blob_client.assert_called_once_with("valkey/2026-05-13T10:00:00Z")
+
+
+def test_azurebackend_download_wraps_http_errors(mocker):
+    from common.exceptions import StorageBackendError
+
+    backend, container = _az_backend(mocker)
+    container.get_blob_client.return_value.download_blob.side_effect = _http_error("BlobNotFound")
+
+    with pytest.raises(StorageBackendError) as excinfo:
+        backend.download("2026-05-13T10:00:00Z")
+    assert excinfo.value.safe_code == "BlobNotFound"
+
+
+def test_azurebackend_delete_removes_the_backup_id_blob(mocker):
+    backend, container = _az_backend(mocker)
+
+    backend.delete("2026-05-13T10:00:00Z")
+
+    container.get_blob_client.assert_called_once_with("valkey/2026-05-13T10:00:00Z")
+    container.get_blob_client.return_value.delete_blob.assert_called_once()
+
+
+def test_azurebackend_delete_swallows_errors(mocker):
+    """Cleanup is best-effort: it must never mask the failure that triggered it."""
+    backend, container = _az_backend(mocker)
+    container.get_blob_client.return_value.delete_blob.side_effect = _http_error("BlobNotFound")
+
+    backend.delete("2026-05-13T10:00:00Z")  # must not raise
+
+
+def test_build_backend_selects_the_azure_backend(mocker):
+    from common.storage_backend import AzureBackend, build_backend
+
+    assert isinstance(build_backend(_az_params(), mocker.MagicMock()), AzureBackend)
+
+
+def test_azurebackend_container_client_is_scoped_to_the_configured_container(mocker):
+    """Every blob operation goes through this, so the container name must reach it."""
+    from src.common import storage_backend
+    from src.common.storage_backend import AzureBackend
+
+    service_cls = mocker.patch.object(storage_backend, "BlobServiceClient")
+
+    container = AzureBackend(_az_params(container="valkey-backups"))._container()
+
+    service_cls.return_value.get_container_client.assert_called_once_with("valkey-backups")
+    assert container is service_cls.return_value.get_container_client.return_value


### PR DESCRIPTION
Adds Azure Blob as a backup store alongside S3.

Relate `azure-storage-integrator` on `azure-credentials`. The two backends
are mutually exclusive: relate both and the app blocks; remove one and the
survivor converges on its own.

Six commits, each green and reviewable on its own.

Two things worth a reviewer's attention:
- The account name is passed to `BlobServiceClient` explicitly. Given a bare
  key the SDK infers it from the hostname, which fails outright for any
  endpoint that isn't `<account>.blob.*` (emulator, custom domain).
- `_az_error_code` reads `.value`; `error_code` is a `(str, Enum)` whose
  `str()` is `StorageErrorCode.AUTHENTICATION_FAILED`, and action results
  are world-readable.