### PR TITLE
chore: pin charmcraft snap revisions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
     with:
       track: ${{ matrix.charm.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      charmcraft-snap-revision: '{"amd64": "8022", "arm64": "8030"}'
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
After the release of charmcraft 4.4.1 to stable, candid auth does not longer work for releasing charms to edge. Until this repo was migrated to a newer version of data platform workflows including the security token refresh, this PR is to unblock releases.

Example for failed release: https://github.com/canonical/valkey-operator/actions/runs/32941545050/job/98119337333