### PR TITLE
docs: document the Authentik LDAP outpost alongside GLAuth

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -73,6 +73,8 @@ Valkey
 failover
 mTLS
 GLAuth
+Authentik
+outpost
 linkcheck
 unmanaged
 venv

--- a/docs/how-to/ldap.md
+++ b/docs/how-to/ldap.md
@@ -16,8 +16,12 @@ The following components are required before proceeding:
 
 ## Deploy LDAP server charm
 
-The exact way we deploy the [`glauth-k8s` charm](https://charmhub.io/glauth-k8s) depends
-on the substrate Charmed Valkey runs on:
+Charmed Valkey works with any provider of the `ldap` interface. This guide covers the two
+Canonical-maintained ones: the [Authentik LDAP outpost](https://charmhub.io/authentik-ldap-outpost),
+which exposes an Authentik directory over LDAP, and [GLAuth](https://charmhub.io/glauth-k8s), a
+lightweight LDAP server. Both are Kubernetes charms.
+
+The exact way you deploy them depends on the substrate Charmed Valkey runs on:
 
 `````{tab-set}
 :sync-group: substrate
@@ -25,9 +29,8 @@ on the substrate Charmed Valkey runs on:
 ````{tab-item} VM
 :sync: vm
 
-Use a separate Juju controller with a Kubernetes model to deploy `glauth-k8s`
-(see the [GLAuth tutorial](https://canonical-identity.readthedocs-hosted.com/tutorial/charms/glauth/)
-for a walkthrough). You will create a
+Use a separate Juju controller with a Kubernetes model to deploy the LDAP provider. You will
+create a
 [cross-model relation](https://documentation.ubuntu.com/juju/3.6/howto/manage-relations/index.html#add-a-cross-model-relation)
 to the Valkey VM model later in this guide.
 ````
@@ -35,24 +38,77 @@ to the Valkey VM model later in this guide.
 ````{tab-item} K8s
 :sync: k8s
 
-No separate Juju model is required -- run `glauth-k8s` alongside Charmed
+No separate Juju model is required -- run the LDAP provider alongside Charmed
 Valkey in the same model.
 ````
 
 `````
 
-Now deploy `glauth-k8s`, `self-signed-certificates`, and `postgresql-k8s`:
+```{caution}
+**[Self-signed certificates](https://en.wikipedia.org/wiki/Self-signed_certificate) are not recommended for a production environment.**
+
+Check the [Choosing a TLS provider](https://canonical-certificate-management.readthedocs-hosted.com/operator/understanding-tls/#choosing-a-tls-provider) page for an overview of all the TLS certificates charms available. 
+```
+
+`````{tab-set}
+:sync-group: ldap-provider
+
+````{tab-item} Authentik
+:sync: authentik
+
+Deploy the Authentik server, its worker, the LDAP outpost, and the supporting
+database, ingress, and certificate charms:
+
+```shell
+juju deploy postgresql-k8s --channel 14/stable --trust
+juju deploy authentik-server --channel latest/stable --trust
+juju deploy authentik-worker --channel latest/stable --trust
+juju deploy authentik-ldap-outpost --channel latest/stable --trust
+juju deploy traefik-k8s --trust
+juju deploy self-signed-certificates
+```
+
+Integrate them:
+
+```shell
+juju integrate authentik-server:pg-database postgresql-k8s:database
+juju integrate authentik-server:authentik-cluster authentik-worker
+juju integrate authentik-server:authentik-server-info authentik-ldap-outpost
+juju integrate authentik-server:traefik-route traefik-k8s
+juju integrate authentik-ldap-outpost:traefik-route traefik-k8s
+juju integrate traefik-k8s:certificates self-signed-certificates
+```
+
+Traefik is required, not optional: the outpost does not provision a certificate
+of its own, so Traefik terminates LDAPS for it on port 636.
+
+Users and groups are managed in Authentik itself. To reach its web interface,
+generate a recovery link for the bootstrap administrator:
+
+```shell
+juju run authentik-server/leader create-recovery-link
+```
+
+```{note}
+The outpost defaults to `search_mode=cached` and `bind_mode=cached`, which serve
+a periodically refreshed snapshot of the directory. Directory changes -- new
+users, changed group membership, changed passwords -- can take until the next
+synchronization to reach Valkey. Set both to `direct` if every request must
+reflect the live Authentik state.
+```
+````
+
+````{tab-item} GLAuth
+:sync: glauth
+
+Deploy `glauth-k8s`, `self-signed-certificates`, and `postgresql-k8s`
+(see the [GLAuth tutorial](https://canonical-identity.readthedocs-hosted.com/tutorial/charms/glauth/)
+for a walkthrough):
 
 ```shell
 juju deploy glauth-k8s --channel latest/edge --trust
 juju deploy self-signed-certificates
 juju deploy postgresql-k8s --channel 14/stable --trust
-```
-
-```{caution}
-**[Self-signed certificates](https://en.wikipedia.org/wiki/Self-signed_certificate) are not recommended for a production environment.**
-
-Check the [Choosing a TLS provider](https://canonical-certificate-management.readthedocs-hosted.com/operator/understanding-tls/#choosing-a-tls-provider) page for an overview of all the TLS certificates charms available. 
 ```
 
 Integrate `glauth-k8s` with `self-signed-certificates` and `postgresql-k8s`:
@@ -71,6 +127,9 @@ juju integrate glauth-k8s glauth-utils
 ```
 
 Users and groups can now be created using [glauth-utils](https://github.com/canonical/glauth-utils/blob/main/SAMPLES.md).
+````
+
+`````
 
 ## Create a cross-model relation
 
@@ -82,31 +141,28 @@ Whether this step is needed depends on the substrate Charmed Valkey runs on:
 ````{tab-item} VM
 :sync: vm
 
-GLAuth runs on a separate Kubernetes controller and model, so Valkey needs a
-cross-model relation to reach it.
+The LDAP provider runs on a separate Kubernetes controller and model, so Valkey
+needs a cross-model relation to reach it.
 
 **Expose LDAP**
 
-Deploy the [Traefik charm](https://charmhub.io/traefik-k8s) to expose LDAP
-endpoints from the Kubernetes cluster:
+Traefik exposes the LDAP endpoint outside the Kubernetes cluster. The Authentik
+outpost is already related to it; for GLAuth, deploy and integrate Traefik now:
 
 ```shell
 juju deploy traefik-k8s --trust
-```
-
-Integrate Traefik with the LDAP server:
-
-```shell
 juju integrate traefik-k8s:ingress glauth-k8s:ingress-per-unit
 ```
 
 **Expose cross-model relations**
 
-To offer the GLAuth interfaces, run:
+Offer the `ldap` endpoint of the provider you deployed -- `authentik-ldap-outpost`
+or `glauth-k8s` -- together with the CA certificate of the charm that issued its
+serving certificate:
 
 ```shell
-juju offer glauth-k8s:ldap ldap
-juju offer glauth-k8s:send-ca-cert send-ca-cert
+juju offer <ldap_provider>:ldap ldap
+juju offer self-signed-certificates:send-ca-cert send-ca-cert
 ```
 
 **Consume offers**
@@ -128,7 +184,7 @@ juju consume <k8s_controller>:admin/<k8s-model-name>.send-ca-cert
 ````{tab-item} K8s
 :sync: k8s
 
-GLAuth already shares the same Juju model as Charmed Valkey, so no
+The LDAP provider already shares the same Juju model as Charmed Valkey, so no
 cross-model relation is required. Proceed to the next section:
 {ref}`define-roles`.
 ````
@@ -191,21 +247,84 @@ to your defined roles in Valkey:
 juju config valkey ldap-map="<ldap_group_name>:ldap_users_write,<another_ldap_group>:ldap_users_read"
 ```
 
-Due to a limitation in GLAuth, it might also be required to configure the attribute that contains 
-the username in the LDAP directory:
+Two more settings depend on how your directory names groups and exposes user DNs.
+
+Valkey lists the members of a group named in `ldap-map` with the query in
+`ldap-query-template`, substituting `{group}` with the group name. It then binds as the user
+whose DN it reads from the attribute named in `ldap-search-dn-attribute`.
+
+`````{tab-set}
+:sync-group: ldap-provider
+
+````{tab-item} Authentik
+:sync: authentik
+
+Authentik names groups with a `cn` RDN, which the default `ldap-query-template`
+already matches -- leave it alone.
+
+Authentik publishes no attribute holding an entry's DN. It does render a user's
+Authentik attributes as LDAP attributes, substituting `%s` with the username, so
+give every user an attribute holding its own bind DN. In the Authentik interface,
+add this to each user's **Attributes**, substituting your configured base DN:
+
+```yaml
+entryDN: cn=%s,ou=users,dc=ldap,dc=goauthentik,dc=io
+```
+
+Then point Valkey at that attribute:
+
+```shell
+juju config valkey ldap-search-dn-attribute="entryDN"
+```
+````
+
+````{tab-item} GLAuth
+:sync: glauth
+
+GLAuth models groups as organizational units rather than the `cn` the default
+template expects, so override it:
+
+```shell
+juju config valkey ldap-query-template='(&(objectClass=posixAccount)(memberOf=ou={group},*))'
+```
+
+GLAuth also returns no DN attribute, so fall back to the email address of your
+LDAP users:
 
 ```shell
 juju config valkey ldap-search-dn-attribute="mail"
 ```
+````
+
+`````
 
 ## Enable LDAP
 
-After completing all required configuration, integrate Valkey with GLAuth to enable LDAP::
+After completing all required configuration, integrate Valkey with the LDAP provider and with the
+charm holding the CA certificate that signed the provider's serving certificate:
+
+`````{tab-set}
+:sync-group: ldap-provider
+
+````{tab-item} Authentik
+:sync: authentik
 
 ```shell
-juju integrate valkey:ldap-ca-cert glauth-k8s:send-ca-cert
+juju integrate valkey:ldap-ca-cert self-signed-certificates:send-ca-cert
+juju integrate valkey:ldap authentik-ldap-outpost:ldap
+```
+````
+
+````{tab-item} GLAuth
+:sync: glauth
+
+```shell
+juju integrate valkey:ldap-ca-cert self-signed-certificates:send-ca-cert
 juju integrate valkey:ldap glauth-k8s:ldap
 ```
+````
+
+`````
 
 Wait for the deployment to settle and log in to Valkey with the username and password from LDAP.
 The permissions in Valkey are set up according to the defined roles and the configured role mapping.
@@ -255,11 +374,11 @@ This will update the ACL files on all units.
 
 ## Disable LDAP
 
-You can disable LDAP in Valkey by removing the relations with GLAuth:
+You can disable LDAP in Valkey by removing the relations with the LDAP provider:
 
 ```shell
-juju remove-relation valkey:ldap-ca-cert glauth-k8s:send-ca-cert
-juju remove-relation valkey:ldap glauth-k8s:ldap
+juju remove-relation valkey:ldap-ca-cert self-signed-certificates:send-ca-cert
+juju remove-relation valkey:ldap <ldap_provider>:ldap
 ```
 
 This removes all LDAP users that were previously added to Valkey's ACL files.  


### PR DESCRIPTION
The LDAP how-to assumed GLAuth from start to finish — deployment, the cross-model
relation, role mapping, and the enable/disable commands all named `glauth-k8s`
directly. Now that the charm works with any provider of the `ldap` interface, the
guide covers both.

## What changed

Provider-specific steps become tab-sets, so either provider can be followed end to
end without mentally substituting names:

- **Deploy** — the full Authentik stack (`authentik-server`, `authentik-worker`,
  `authentik-ldap-outpost`, plus PostgreSQL, Traefik and a certificate provider),
  or the existing GLAuth stack.
- **Configure role mapping** — `ldap-query-template` and `ldap-search-dn-attribute`
  differ per provider.
- **Enable LDAP** — which application to relate `ldap-ca-cert` to.

The substrate tab-set (VM / K8s) is unchanged; the cross-model section is now
provider-neutral.

## What it records that is not obvious

- **Traefik is mandatory for the outpost**, not optional: it never provisions a
  certificate of its own, so Traefik terminates LDAPS for it on 636.
- **The CA comes from the certificate provider**, not from the LDAP server. The
  outpost has no `send-ca-cert`, and GLAuth's is certificate-transfer v0, which the
  charm no longer consumes.
- **Authentik publishes no DN attribute**, so `ldap-search-dn-attribute` has nothing
  to read by default. It does render user attributes with `%s` substituted for the
  username, so each user gets `entryDN: cn=%s,ou=users,<base_dn>`. The GLAuth `mail`
  workaround cannot work here — Authentik's binder requires a `cn=...,<base_dn>` DN.
- **The outpost's `search_mode`/`bind_mode` default to `cached`**, which can serve a
  stale directory to Valkey — new users, changed group membership and changed
  passwords may not take effect until the next synchronization.