### PR TITLE
chore: fix charmcraft revisions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
     with:
       track: ${{ matrix.charm.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
-      charmcraft-snap-revision: '{"amd64": "8022", "arm64": "8030"}'
+      charmcraft-snap-revisions: '{"amd64": "8022", "arm64": "8030"}'
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
`charmcraft-snap-revision` must be `charmcraft-snap-revisions`